### PR TITLE
Add environment setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,16 @@ FlowRunner configuration happens primarily through the user interface:
     *   Try restarting the packaged application.
     *   For more advanced debugging, you can open the **Developer Tools** from the **View** menu (`View > Toggle Developer Tools`). Check the **Console** tab within the Developer Tools for any error messages logged by the application.
 
+## Development Setup
+
+To set up a local environment for testing or packaging, run:
+
+```bash
+./setup_env.sh
+```
+
+This script verifies npm availability, warns if your Node.js version is below 18, installs dependencies (using `npm ci` when possible), and downloads Playwright browsers.
+
 
 <div align="center" style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee;">
   <img src="assets/Radware_logo.svg" alt="Radware Logo" height="40">

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure npm is available
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but was not found. Please install Node.js and npm." >&2
+  exit 1
+fi
+
+# Warn if Node.js version is below 18
+node_ver=$(node -v | sed 's/^v//')
+node_major=${node_ver%%.*}
+if [ "$node_major" -lt 18 ]; then
+  echo "Warning: Node.js 18 or higher is recommended. Current version: v$node_ver" >&2
+fi
+
+# Install Node dependencies
+if [ -f package-lock.json ]; then
+  npm ci
+else
+  npm install
+fi
+
+# Install Playwright browsers
+npx playwright install --with-deps
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- add `setup_env.sh` for easy dependency setup
- document the script in README

## Testing
- `npm test`
- `npm run e2e` *(fails: electron.launch: Process failed to launch)*

------
https://chatgpt.com/codex/tasks/task_b_684e76e281bc83209c0ca7b2f61aef27