### PR TITLE
Enable electron in headless environment

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,6 +31,11 @@ if (process.env.E2E || process.env.NODE_ENV === 'test') {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Allow running Electron as root in headless environments
+if (process.platform === 'linux' && process.getuid && process.getuid() === 0) {
+    app.commandLine.appendSwitch('no-sandbox');
+}
+
 let mainWindow; // Global reference
 let helpWindow = null; // Keep track of the help window
 let forceQuit = false; // Flag to bypass prompts if user confirmed quit

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "make": "electron-forge make",
     "lint": "echo \"Error: no lint script specified\" && exit 0",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "e2e": "NODE_ENV=test playwright test"
+    "e2e": "NODE_ENV=test xvfb-run -a -s \"-screen 0 1280x720x24\" playwright test"
   },
   "repository": {
     "type": "git",

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -24,4 +24,10 @@ fi
 # Install Playwright browsers
 npx playwright install --with-deps
 
+# Start a virtual display if none is available (for Electron)
+if [ -z "$DISPLAY" ] && command -v Xvfb >/dev/null 2>&1; then
+    Xvfb :99 -screen 0 1280x720x24 >/tmp/xvfb.log 2>&1 &
+    export DISPLAY=:99
+fi
+
 echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- allow running Electron as root by disabling sandbox
- start Xvfb virtual display in setup_env.sh
- run e2e tests under Xvfb

## Testing
- `npm test`
- `npm run e2e` *(fails: 3 failed)*

------
https://chatgpt.com/codex/tasks/task_b_684ea8f414b48320b419040276b6198d