### PR TITLE
Handle 204 No Content responses

### DIFF
--- a/flowRunner.js
+++ b/flowRunner.js
@@ -669,12 +669,24 @@ export class FlowRunner {
             const responseHeaders = {};
             response.headers.forEach((value, key) => { responseHeaders[key] = value; });
             let responseBody = null;
-            const respContentType = response.headers.get('content-type');
-            try {
-                if (respContentType && respContentType.includes('application/json')) { responseBody = await response.json(); }
-                else { responseBody = await response.text(); }
-            } catch (parseError) {
-                try { responseBody = await response.text(); } catch (textError) { responseBody = "[Failed to retrieve response body]"; this.onMessage(`Response body parsing failed and text fallback failed: ${textError.message}`, 'error'); } this.onMessage(`Response body parsing failed: ${parseError.message}. Using raw text fallback.`, 'warning');
+
+            if (responseStatus !== 204) {
+                const respContentType = response.headers.get('content-type');
+                try {
+                    if (respContentType && respContentType.includes('application/json')) {
+                        responseBody = await response.json();
+                    } else {
+                        responseBody = await response.text();
+                    }
+                } catch (parseError) {
+                    try {
+                        responseBody = await response.text();
+                    } catch (textError) {
+                        responseBody = "[Failed to retrieve response body]";
+                        this.onMessage(`Response body parsing failed and text fallback failed: ${textError.message}`, 'error');
+                    }
+                    this.onMessage(`Response body parsing failed: ${parseError.message}. Using raw text fallback.`, 'warning');
+                }
             }
 
             // --- MODIFICATION START: Implement onFailure logic for HTTP status (remains the same logic) ---


### PR DESCRIPTION
## Summary
- skip body parsing when HTTP response code is 204 in `_executeRequestStep`
- test: verify 204 responses are handled without warnings and succeed

## Testing
- `npm test`
- `npm run e2e` *(fails: unexpected text in e2e tests)*

------
https://chatgpt.com/codex/tasks/task_b_684ecaf4a5e483208687566830d129d1