### PR TITLE
Add typed flow variables and schema

### DIFF
--- a/__tests__/flowBuilderComponent.test.js
+++ b/__tests__/flowBuilderComponent.test.js
@@ -274,6 +274,8 @@ describe('FlowBuilderComponent', () => {
 
     test('stores JSON variable values as objects', () => {
         componentInstance._addFlowVarRow('arr', '[1,2]', false);
+        const row = domRefs.infoOverlayFlowVarsList.lastElementChild;
+        row.querySelector('.flow-var-type').value = 'json';
         const vars = componentInstance._getCurrentFlowVarsFromUI();
         expect(vars).toEqual({ arr: [1, 2] });
     });
@@ -281,6 +283,7 @@ describe('FlowBuilderComponent', () => {
     test('JSON array variable drives loop iterations', async () => {
         jest.useFakeTimers({ now: Date.now() });
         componentInstance._addFlowVarRow('arr', '[1,2,3]', false);
+        domRefs.infoOverlayFlowVarsList.lastElementChild.querySelector('.flow-var-type').value = 'json';
         const flow = createTemplateFlow();
         flow.staticVars = { arr: [1, 2, 3] };
         flow.steps = [{

--- a/app.js
+++ b/app.js
@@ -409,8 +409,25 @@ function getCurrentFlowVarsFromUI() {
      domRefs.infoOverlayFlowVarsList?.querySelectorAll('.flow-var-row').forEach(row => {
          const keyInput = row.querySelector('.flow-var-key');
          const valueInput = row.querySelector('.flow-var-value');
+         const typeSelect = row.querySelector('.flow-var-type');
          const key = keyInput?.value.trim();
-         const value = valueInput?.value; // Allow empty values
+         const rawValue = valueInput?.value; // Allow empty values
+
+         let value;
+         switch (typeSelect?.value) {
+              case 'number':
+                  value = Number(rawValue);
+                  if (Number.isNaN(value)) value = rawValue;
+                  break;
+              case 'boolean':
+                  value = String(rawValue).toLowerCase() === 'true';
+                  break;
+              case 'json':
+                  try { value = JSON.parse(rawValue); } catch (e) { value = rawValue; }
+                  break;
+              default:
+                  value = rawValue;
+         }
 
          if (key && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) { // Validate variable name format
               staticVars[key] = value ?? '';
@@ -435,12 +452,29 @@ function addFlowVarRow(key, value, container) { // `container` is passed from ha
     row.className = 'flow-var-row';
     const keyId = `fv-key-global-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
     const valueId = `fv-val-global-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+    const typeId = `fv-type-global-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+
+    let detectedType = 'string';
+    if (typeof value === 'number') detectedType = 'number';
+    else if (typeof value === 'boolean') detectedType = 'boolean';
+    else if (typeof value === 'object' && value !== null) {
+        detectedType = 'json';
+        try { value = JSON.stringify(value); } catch (e) { value = String(value); }
+    }
+
     row.innerHTML = `
         <input type="text" class="flow-var-key" id="${keyId}" value="${escapeHTML(key)}" placeholder="Variable Name (letters, numbers, _)">
-        <input type="text" class="flow-var-value" id="${valueId}" value="${escapeHTML(value)}" placeholder="Variable Value (JSON supported)">
+        <input type="text" class="flow-var-value" id="${valueId}" value="${escapeHTML(value)}" placeholder="Variable Value">
+        <select class="flow-var-type" id="${typeId}">
+            <option value="string">String</option>
+            <option value="number">Number</option>
+            <option value="boolean">Boolean</option>
+            <option value="json">JSON</option>
+        </select>
         <button class="btn-insert-var" data-target-input="${valueId}" title="Insert Variable">{{…}}</button>
         <button class="btn-remove-flow-var" title="Remove Variable">✕</button>
     `;
+    row.querySelector('.flow-var-type').value = detectedType;
     container.appendChild(row);
     adjustCollapsibleHeight(domRefs.infoOverlayFlowVarsToggle, domRefs.infoOverlayFlowVarsContent);
 }

--- a/schemas/flow-v1.schema.json
+++ b/schemas/flow-v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FlowRunner Flow v1.0",
+  "type": "object",
+  "required": ["id", "name", "steps"],
+  "properties": {
+    "id": {"type": "string"},
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "headers": {
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+    "staticVars": {
+      "type": "object",
+      "additionalProperties": {}
+    },
+    "steps": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/step"}
+    },
+    "visualLayout": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["x", "y"],
+        "properties": {
+          "x": {"type": "number"},
+          "y": {"type": "number"}
+        }
+      }
+    }
+  },
+  "definitions": {
+    "step": {
+      "type": "object",
+      "required": ["id", "name", "type"],
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "type": {"enum": ["request", "condition", "loop"]},
+        "onFailure": {"enum": ["stop", "continue"]},
+        "headers": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "url": {"type": "string"},
+        "method": {"type": "string"},
+        "body": {},
+        "extract": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "thenSteps": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/step"}
+        },
+        "elseSteps": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/step"}
+        },
+        "condition": {"type": "string"},
+        "conditionData": {
+          "type": "object",
+          "properties": {
+            "variable": {"type": "string"},
+            "operator": {"type": "string"},
+            "value": {}
+          }
+        },
+        "source": {"type": "string"},
+        "loopVariable": {"type": "string"},
+        "loopSteps": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/step"}
+        }
+      }
+    }
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1104,7 +1104,7 @@ button:disabled {
 .headers-list, .extracts-list, .global-headers-list, .flow-vars-list {
     margin-bottom: 10px;
 }
-.header-row, .extract-row, .global-header-row, .flow-var-row { display: grid; grid-template-columns: minmax(120px, 1fr) minmax(150px, 2fr) auto auto; gap: 10px; align-items: center; margin-bottom: 8px; padding-bottom: 8px; border-bottom: 1px solid var(--border-color-light); }
+.header-row, .extract-row, .global-header-row, .flow-var-row { display: grid; grid-template-columns: minmax(120px, 1fr) minmax(150px, 2fr) minmax(90px, 1fr) auto auto; gap: 10px; align-items: center; margin-bottom: 8px; padding-bottom: 8px; border-bottom: 1px solid var(--border-color-light); }
 .header-row:last-child, .extract-row:last-child, .global-header-row:last-child, .flow-var-row:last-child { border-bottom: none; margin-bottom: 0; }
 .header-row input, .extract-row input, .global-header-row input, .flow-var-row input { min-width: 0; width: 100%; }
 .header-row .btn-insert-var, .extract-row .btn-insert-var, .global-header-row .btn-insert-var, .flow-var-row .btn-insert-var { padding: 0; width: 24px; height: 24px; font-size: 12px; border: 1px solid var(--border-color-medium); background: var(--light-bg-color); border-radius: 3px; color: var(--primary-color); line-height: 22px; text-align: center; align-self: center; justify-self: center; }
@@ -1405,7 +1405,7 @@ body.flow-step-dragging { cursor: grabbing !important; }
           linear-gradient(transparent 45%,#bdbdbd 45%,#bdbdbd 55%,transparent 55%);
         background-size:100% 4px;
       }
-    .header-row, .extract-row, .global-header-row, .flow-var-row { grid-template-columns: 1fr auto auto; }
+    .header-row, .extract-row, .global-header-row, .flow-var-row { grid-template-columns: 1fr auto auto auto; }
     .header-row input, .extract-row input, .global-header-row input, .flow-var-row input { grid-column: 1 / 2; }
     .header-row input:nth-of-type(2), .extract-row input:nth-of-type(2), .global-header-row input:nth-of-type(2), .flow-var-row input:nth-of-type(2) { margin-top: 5px; }
     .header-row .btn-insert-var, .extract-row .btn-insert-var, .global-header-row .btn-insert-var, .flow-var-row .btn-insert-var { grid-column: 2 / 3; grid-row: 1 / 3; align-self: center; }

--- a/uiUtils.js
+++ b/uiUtils.js
@@ -387,12 +387,29 @@ function _addFlowVarRow(key, value, triggerUpdate = true) {
     row.className = 'flow-var-row';
     const keyId = `fv-key-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
     const valueId = `fv-val-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+    const typeId = `fv-type-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+
+    let detectedType = 'string';
+    if (typeof value === 'number') detectedType = 'number';
+    else if (typeof value === 'boolean') detectedType = 'boolean';
+    else if (typeof value === 'object' && value !== null) {
+        detectedType = 'json';
+        try { value = JSON.stringify(value); } catch (e) { value = String(value); }
+    }
+
     row.innerHTML = `
         <input type="text" class="flow-var-key" id="${keyId}" value="${escapeHTML(key)}" placeholder="Variable Name (letters, numbers, _)">
-        <input type="text" class="flow-var-value" id="${valueId}" value="${escapeHTML(value)}" placeholder="Variable Value (JSON supported)">
+        <input type="text" class="flow-var-value" id="${valueId}" value="${escapeHTML(value)}" placeholder="Variable Value">
+        <select class="flow-var-type" id="${typeId}">
+            <option value="string">String</option>
+            <option value="number">Number</option>
+            <option value="boolean">Boolean</option>
+            <option value="json">JSON</option>
+        </select>
         <button class="btn-insert-var" data-target-input="${valueId}" title="Insert Variable">{{…}}</button>
         <button class="btn-remove-flow-var" title="Remove Variable">✕</button>
     `;
+    row.querySelector('.flow-var-type').value = detectedType;
     container.appendChild(row);
 
     // Removed local event listeners - handled globally in app.js
@@ -412,13 +429,24 @@ function _getCurrentFlowVarsFromUI() {
     domRefs.infoOverlayFlowVarsList?.querySelectorAll('.flow-var-row').forEach(row => {
         const keyInput = row.querySelector('.flow-var-key');
         const valueInput = row.querySelector('.flow-var-value');
+        const typeSelect = row.querySelector('.flow-var-type');
         const key = keyInput?.value.trim();
-        let value = valueInput?.value || '';
-        if (typeof value === 'string') {
-            const trimmed = value.trim();
-            if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
-                try { value = JSON.parse(trimmed); } catch (e) { /* keep string */ }
-            }
+        const rawValue = valueInput?.value || '';
+
+        let value;
+        switch (typeSelect?.value) {
+            case 'number':
+                value = Number(rawValue);
+                if (Number.isNaN(value)) value = rawValue;
+                break;
+            case 'boolean':
+                value = rawValue.toLowerCase() === 'true';
+                break;
+            case 'json':
+                try { value = JSON.parse(rawValue); } catch (e) { value = rawValue; }
+                break;
+            default:
+                value = rawValue;
         }
 
         if (key && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(key)) {


### PR DESCRIPTION
## Summary
- allow specifying type for flow variables (string, number, boolean, json)
- parse global variable values based on selected type
- extend UI for new variable type selector
- create `schemas/flow-v1.schema.json` for FlowRunner flows

## Testing
- `npm test`
- `npm run e2e` *(fails: unexpected value "ERROR" in step results)*

------
https://chatgpt.com/codex/tasks/task_b_684efffde21c8320982635900be78985