### PR TITLE
Fix e2e tests to rely on local mock server

### DIFF
--- a/e2e/flow-execution.e2e.test.js
+++ b/e2e/flow-execution.e2e.test.js
@@ -3,7 +3,7 @@
     – fixes invalid matcher, aligns with real title.
     – UPDATED: flowPath to look in e2e-test-data
     – UPDATED: "Run flow" test to wait more robustly for results
-    – UPDATED: Dynamically create httpbin-flow.flow.json in test.beforeAll
+    – UPDATED: Dynamically create mock-flow.flow.json in test.beforeAll
 */
 
 import { test, expect, _electron as electron } from '@playwright/test';
@@ -19,19 +19,19 @@ const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
 const projectRoot     = path.resolve(__dirname, '..'); // Renamed for clarity
 const testDataDir     = path.resolve(__dirname, 'e2e-test-data'); // Define test data directory
-const flowPath        = path.resolve(testDataDir, 'httpbin-flow.flow.json'); // Path for the flow file
+const flowPath        = path.resolve(testDataDir, 'mock-flow.flow.json'); // Path for the flow file
 
 const RECENT_FILES_KEY = 'flowrunnerRecentFiles';
 const MAX_RECENT_FILES = 10;
-const FLOW_TITLE       = 'E2E All‑Features HTTPBin Flow';
-let httpServer;
-let httpbinUrl;
+const FLOW_TITLE       = 'E2E All‑Features Mock Flow';
+let mockServer;
+let mockUrl;
 
-// Content for the httpbin-flow.flow.json
-const HTTPBIN_FLOW_CONTENT = {
-  "id": "flow_e2e_httpbin_all_features",
-  "name": "E2E All‑Features HTTPBin Flow",
-  "description": "Comprehensive flow that touches every FlowRunner v1.0.0 feature against https://httpbin.org.",
+// Content for the local mock httpbin flow
+const MOCK_FLOW_CONTENT = {
+  "id": "flow_e2e_mock_all_features",
+  "name": "E2E All‑Features Mock Flow",
+  "description": "Comprehensive flow that touches every FlowRunner v1.0.0 feature using a local mock server.",
   "headers": {
     "X-Global-Header": "FlowRunner E2E",
     "Accept": "application/json"
@@ -307,13 +307,13 @@ test.describe('E2E: Comprehensive Flow Execution', () => {
   test.beforeAll(async () => {
     console.log('--- E2E flow-execution setup ---');
 
-    ({ server: httpServer, baseUrl: httpbinUrl } = await startHttpbinServer());
-    HTTPBIN_FLOW_CONTENT.staticVars.baseUrl = httpbinUrl;
+    ({ server: mockServer, baseUrl: mockUrl } = await startHttpbinServer());
+    MOCK_FLOW_CONTENT.staticVars.baseUrl = mockUrl;
 
     // Ensure the test data directory exists
     await fs.mkdir(testDataDir, { recursive: true });
     // Write the flow file content dynamically
-    await fs.writeFile(flowPath, JSON.stringify(HTTPBIN_FLOW_CONTENT, null, 2));
+    await fs.writeFile(flowPath, JSON.stringify(MOCK_FLOW_CONTENT, null, 2));
     console.log(`[E2E flow-execution setup] Dynamically created flow file at: ${flowPath}`);
 
     // The fs.access check is now redundant here if we just created it, but good for sanity
@@ -370,7 +370,7 @@ test.describe('E2E: Comprehensive Flow Execution', () => {
   // Modified afterAll to clean up the dynamically created file and directory if it's empty
   test.afterAll(async () => {
     if (app) await app.close();
-    if (httpServer) await stopHttpbinServer(httpServer);
+    if (mockServer) await stopHttpbinServer(mockServer);
     try {
       await fs.rm(flowPath, { force: true }); // Remove the specific flow file
       console.log(`[E2E flow-execution teardown] Removed flow file: ${flowPath}`);

--- a/e2e/simple-request-flow.e2e.test.js
+++ b/e2e/simple-request-flow.e2e.test.js
@@ -15,8 +15,8 @@ const simpleFlowPath  = path.join(testDataRoot, 'simple-request.flow.json');
 
 const RECENT_FILES_KEY = 'flowrunnerRecentFiles';
 const MAX_RECENT_FILES = 10;
-let httpServer;
-let httpbinUrl;
+let mockServer;
+let mockUrl;
 
 async function pushToRecentFiles(page, filePath) {
   return page.evaluate(
@@ -62,7 +62,7 @@ test.describe('E2E: Simple Request Flow Execution', () => {
   test.beforeAll(async () => {
     console.log('--- E2E Setup (simple-request) ---');
     await fs.mkdir(testDataRoot, { recursive: true });
-    ({ server: httpServer, baseUrl: httpbinUrl } = await startHttpbinServer());
+    ({ server: mockServer, baseUrl: mockUrl } = await startHttpbinServer());
 
     const flow = {
       name : 'Simple Request Flow',
@@ -72,7 +72,7 @@ test.describe('E2E: Simple Request Flow Execution', () => {
           name : 'Get IP',
           type : 'request',
           method: 'GET',
-          url  : `${httpbinUrl}/get`,
+          url  : `${mockUrl}/get`,
           headers: { Accept: 'application/json' },
           body : '',
           extract: { clientIp: 'body.origin' },
@@ -83,7 +83,7 @@ test.describe('E2E: Simple Request Flow Execution', () => {
           name : 'Get UUID',
           type : 'request',
           method: 'GET',
-          url  : `${httpbinUrl}/uuid`,
+          url  : `${mockUrl}/uuid`,
           headers: { Accept: 'application/json' },
           body : '',
           extract: { uuid: 'body.uuid' },
@@ -128,7 +128,7 @@ test.describe('E2E: Simple Request Flow Execution', () => {
 
   test.afterAll(async () => {
     if (electronApp) await electronApp.close();
-    if (httpServer) await stopHttpbinServer(httpServer);
+    if (mockServer) await stopHttpbinServer(mockServer);
     try { await fs.rm(simpleFlowPath, { force: true }); } catch {}
   });
 


### PR DESCRIPTION
## Summary
- rename HTTPBin references in e2e tests to use a local mock server
- adjust paths and flow IDs accordingly

## Testing
- `npm test`
- `npm run e2e` *(fails: unexpected ERROR status)*

------
https://chatgpt.com/codex/tasks/task_b_684f02686aec832089fcb6420a2be42f