### PR TITLE
Fix e2e tests using local mock server

### DIFF
--- a/e2e/simple-request-flow.e2e.test.js
+++ b/e2e/simple-request-flow.e2e.test.js
@@ -103,14 +103,15 @@ test.describe('E2E: Simple Request Flow Execution', () => {
     page.setDefaultTimeout(20_000);
     setupRendererLogCapture(page); // <-- Capture renderer logs to file
 
+    // Ensure a clean recent files list
+    await page.evaluate(key => localStorage.setItem(key, '[]'), RECENT_FILES_KEY);
     await pushToRecentFiles(page, simpleFlowPath);
     await page.reload();
     await page.waitForLoadState('domcontentloaded');
 
-    const escaped = simpleFlowPath.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    await page.locator(`#flow-list .recent-file-item[data-file-path="${escaped}"]`).click();
+    await page.locator('#flow-list .recent-file-item').filter({ hasText: 'simple-request.flow.json' }).click();
 
-    await expect(page.locator('#workspace-title')).toContainText('Simple Request Flow');
+    await expect(page.locator('#workspace-title')).toContainText('Simple Request Flow', { timeout: 10000 });
 
     // Log loaded flow info for verification
     const loadedFlowInfo = await page.evaluate(() => {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <!-- Recommended practice for Electron apps -->
     <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: assets:; connect-src 'self' http://* https://*; ">
+        content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: assets:; connect-src 'self' http: https:; ">
     <title>FlowRunner</title>
     <link rel="stylesheet" href="styles.css">
 </head>


### PR DESCRIPTION
## Summary
- loosen CSP connect-src so local HTTP mock server works
- reset recent files list before loading sample flow
- wait for workspace title to load
- ensure e2e tests pass when using local resources

## Testing
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_b_684f0b0c8a988320af1139021dd96402