### PR TITLE
Add zoom controls and minimap

### DIFF
--- a/domUtils.js
+++ b/domUtils.js
@@ -33,6 +33,7 @@ export function initializeDOMReferences() {
         toggleVariablesBtn: document.getElementById('toggle-variables-btn'),
         zoomOutBtn: document.getElementById('zoom-out-btn'),
         zoomInBtn: document.getElementById('zoom-in-btn'),
+        zoomResetBtn: document.getElementById('zoom-reset-btn'),
 
         // Panels relative to Workspace
         variablesPanel: document.querySelector('.variables-panel'),

--- a/eventHandlers.js
+++ b/eventHandlers.js
@@ -56,6 +56,7 @@ export function initializeEventListeners() {
     // Zoom Controls
     domRefs.zoomInBtn?.addEventListener('click', () => appState.visualizerComponent?.zoomIn());
     domRefs.zoomOutBtn?.addEventListener('click', () => appState.visualizerComponent?.zoomOut());
+    domRefs.zoomResetBtn?.addEventListener('click', () => appState.visualizerComponent?.resetZoom());
 
     // Info Panel Close Button (Inside Panel) - Explicitly closes
     domRefs.actualInfoOverlayCloseBtn?.addEventListener('click', () => handleToggleInfoOverlay(false));
@@ -159,6 +160,10 @@ export function initializeEventListeners() {
         if (ctrlOrCmd && (e.key === '-' || e.key === '_')) {
             e.preventDefault();
             domRefs.zoomOutBtn?.click();
+        }
+        if (ctrlOrCmd && e.key === '0') {
+            e.preventDefault();
+            domRefs.zoomResetBtn?.click();
         }
 
         // View/Panel Toggles

--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
                     </button>
                     <button id="zoom-out-btn" class="btn btn-sm" title="Zoom Out" style="display: none;">-</button>
                     <button id="zoom-in-btn" class="btn btn-sm" title="Zoom In" style="display: none;">+</button>
+                    <button id="zoom-reset-btn" class="btn btn-sm" title="Reset Zoom" style="display: none;">100%</button>
                 </div>
             </div>
 

--- a/styles.css
+++ b/styles.css
@@ -569,6 +569,18 @@ button:disabled {
     min-height: 100%;
 }
 
+.visualizer-minimap {
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid var(--border-color-medium);
+    box-shadow: var(--box-shadow-light);
+    z-index: 1000;
+}
+
+.minimap-viewport {
+    box-sizing: border-box;
+    background: rgba(59,130,246,0.2);
+}
+
 /* --- Runner Panel --- */
 .runner-panel {
     width: 350px;

--- a/uiUtils.js
+++ b/uiUtils.js
@@ -630,11 +630,13 @@ export function updateViewToggle() {
         if(domRefs.toggleViewBtn) domRefs.toggleViewBtn.style.display = 'none';
         if(domRefs.zoomInBtn) domRefs.zoomInBtn.style.display = 'none';
         if(domRefs.zoomOutBtn) domRefs.zoomOutBtn.style.display = 'none';
+        if(domRefs.zoomResetBtn) domRefs.zoomResetBtn.style.display = 'none';
         return;
     }
     domRefs.toggleViewBtn.style.display = ''; // Ensure button is visible if flow loaded
     if(domRefs.zoomInBtn) domRefs.zoomInBtn.style.display = appState.currentView === 'node-graph' ? '' : 'none';
     if(domRefs.zoomOutBtn) domRefs.zoomOutBtn.style.display = appState.currentView === 'node-graph' ? '' : 'none';
+    if(domRefs.zoomResetBtn) domRefs.zoomResetBtn.style.display = appState.currentView === 'node-graph' ? '' : 'none';
     if (appState.currentView === 'list-editor') {
         domRefs.toggleViewBtn.textContent = 'Visual View';
         domRefs.toggleViewBtn.title = 'Switch to Node-Graph View (Ctrl+3)';


### PR DESCRIPTION
## Summary
- extend `FlowVisualizer` with zoom state management, wheel/pinch zoom handling and minimap
- expose `zoomIn`, `zoomOut`, `resetZoom`
- add zoom reset button and show/hide logic
- hook up new controls and shortcuts
- style minimap overlay

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_685011a876488320a7e69cdf04a99137