### PR TITLE
Add copy button for runner output

### DIFF
--- a/__tests__/runnerInterface.test.js
+++ b/__tests__/runnerInterface.test.js
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach } from '@jest/globals';
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
 import { renderResultItemContent } from '../runnerInterface.js';
 import { appState } from '../state.js';
 
@@ -25,5 +25,25 @@ describe('renderResultItemContent', () => {
         expect(html).toContain('abc');
         expect(html).toContain('id');
         expect(html).toContain('123');
+    });
+
+    test('copy button writes output to clipboard', () => {
+        const writeMock = jest.fn();
+        Object.assign(navigator, { clipboard: { writeText: writeMock } });
+        const li = document.createElement('li');
+        const data = {
+            stepName: 'Req1',
+            stepId: 'r1',
+            status: 'success',
+            output: 'hello',
+            error: null,
+            extractionFailures: [],
+            extractedValues: {}
+        };
+        renderResultItemContent(li, data);
+        const btn = li.querySelector('.copy-btn');
+        expect(btn).not.toBeNull();
+        btn.dispatchEvent(new Event('click'));
+        expect(writeMock).toHaveBeenCalledWith('hello');
     });
 });

--- a/runnerInterface.js
+++ b/runnerInterface.js
@@ -436,7 +436,7 @@ export function renderResultItemContent(listItem, resultData) {
             const outputString = typeof output === 'string' ? output : JSON.stringify(output, null, 2);
             outputHtml = `<div class="result-body"><pre>${escapeHTML(outputString)}</pre></div>`;
         } catch (e) {
-             outputHtml = `<div class="result-body"><pre>[Error formatting output: ${escapeHTML(e.message)}]</pre></div>`;
+            outputHtml = `<div class="result-body"><pre>[Error formatting output: ${escapeHTML(e.message)}]</pre></div>`;
         }
     }
 
@@ -490,4 +490,24 @@ export function renderResultItemContent(listItem, resultData) {
         ${extractedValuesHtml}
         ${outputHtml}
     `;
+
+    if (outputHtml) {
+        const resultBody = listItem.querySelector('.result-body');
+        if (resultBody) {
+            const copyBtn = document.createElement('button');
+            copyBtn.className = 'copy-btn btn btn-sm';
+            copyBtn.textContent = 'Copy';
+            copyBtn.title = 'Copy raw output';
+            copyBtn.setAttribute('aria-label', 'Copy raw output');
+            copyBtn.addEventListener('click', () => {
+                try {
+                    const raw = typeof output === 'string' ? output : JSON.stringify(output, null, 2);
+                    navigator.clipboard.writeText(raw);
+                } catch (err) {
+                    logger.error('Failed to copy output:', err);
+                }
+            });
+            resultBody.appendChild(copyBtn);
+        }
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -114,6 +114,11 @@ code {
     font-size: 0.875em;
 }
 
+.copy-btn {
+    margin-top: 5px;
+    float: right;
+}
+
 button:disabled {
     opacity: 0.6;
     cursor: not-allowed;


### PR DESCRIPTION
## Summary
- add copy-to-clipboard button to each output entry in the runner UI
- style the new copy button
- test copy functionality in runnerInterface unit tests

## Testing
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_b_6850344f93b08320a27ae6fcec66eeb8