### PR TITLE
Mock GitHub update calls in e2e

### DIFF
--- a/e2e/file-operations.e2e.test.js
+++ b/e2e/file-operations.e2e.test.js
@@ -12,6 +12,7 @@ import path   from 'node:path';
 import fs     from 'node:fs/promises';
 import { fileURLToPath } from 'url';
 import fsSync from 'node:fs';
+import { setupMockUpdateRoute, removeMockUpdateRoute } from './mockUpdate.js';
 
 /* ───────────── paths / constants ───────────── */
 
@@ -124,6 +125,7 @@ test.describe('E2E: File Operations', () => {
     page = await electronApp.firstWindow();
     await page.waitForLoadState('domcontentloaded');
     page.setDefaultTimeout(30_000);
+    await setupMockUpdateRoute(page);
     setupRendererLogCapture(page); // <-- Capture renderer logs to file
     console.log('--- Setup complete ---');
   });
@@ -132,6 +134,7 @@ test.describe('E2E: File Operations', () => {
     console.log('--- E2E Teardown (file-operations) ---');
     // --- MODIFICATION: Commented out restoreSaveDialog as it causes errors and is not needed now ---
     // await restoreSaveDialog(electronApp).catch(() => {});
+    if (page) await removeMockUpdateRoute(page).catch(() => {});
     if (electronApp) await electronApp.close();
     await fs.rm(testDataRoot, { recursive: true, force: true }).catch(() => {});
   });

--- a/e2e/flow-execution.e2e.test.js
+++ b/e2e/flow-execution.e2e.test.js
@@ -12,6 +12,7 @@ import fs     from 'node:fs/promises'; // fs/promises for async operations
 import { fileURLToPath } from 'url';
 import fsSync from 'node:fs';
 import { startHttpbinServer, stopHttpbinServer } from './httpbin-server.js';
+import { setupMockUpdateRoute, removeMockUpdateRoute } from './mockUpdate.js';
 
 /* ───────────── paths & constants ───────────── */
 
@@ -333,6 +334,7 @@ test.describe('E2E: Comprehensive Flow Execution', () => {
     page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded', { timeout: 20000 });
     page.setDefaultTimeout(30_000);
+    await setupMockUpdateRoute(page);
     setupRendererLogCapture(page);
 
     await pushRecent(page, flowPath);
@@ -369,6 +371,7 @@ test.describe('E2E: Comprehensive Flow Execution', () => {
 
   // Modified afterAll to clean up the dynamically created file and directory if it's empty
   test.afterAll(async () => {
+    if (page) await removeMockUpdateRoute(page).catch(() => {});
     if (app) await app.close();
     if (mockServer) await stopHttpbinServer(mockServer);
     try {

--- a/e2e/ipc-io.integration.e2e.test.js
+++ b/e2e/ipc-io.integration.e2e.test.js
@@ -4,6 +4,7 @@
 import { test, expect, _electron as electron } from '@playwright/test';
 import path from 'node:path';
 import { fileURLToPath } from 'url';
+import { setupMockUpdateRoute, removeMockUpdateRoute } from './mockUpdate.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -103,9 +104,11 @@ test.describe('IPC and File I/O Integration Tests', () => {
         });
         page = await electronApp.firstWindow();
         await page.waitForLoadState('domcontentloaded');
+        await setupMockUpdateRoute(page);
     });
 
     test.afterAll(async () => {
+        if (page) await removeMockUpdateRoute(page).catch(() => {});
         if (electronApp) {
             await electronApp.close();
         }

--- a/e2e/mockUpdate.js
+++ b/e2e/mockUpdate.js
@@ -1,0 +1,16 @@
+export async function setupMockUpdateRoute(page) {
+    await page.route('https://api.github.com/**', (route) => {
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                tag_name: 'v1.1.0',
+                html_url: 'https://example.com/release/v1.1.0'
+            })
+        });
+    });
+}
+
+export async function removeMockUpdateRoute(page) {
+    await page.unroute('https://api.github.com/**');
+}

--- a/e2e/simple-request-flow.e2e.test.js
+++ b/e2e/simple-request-flow.e2e.test.js
@@ -5,6 +5,7 @@ import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
 import { fileURLToPath } from 'url';
 import { startHttpbinServer, stopHttpbinServer } from './httpbin-server.js';
+import { setupMockUpdateRoute, removeMockUpdateRoute } from './mockUpdate.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -101,6 +102,7 @@ test.describe('E2E: Simple Request Flow Execution', () => {
     page = await electronApp.firstWindow();
     await page.waitForLoadState('domcontentloaded');
     page.setDefaultTimeout(20_000);
+    await setupMockUpdateRoute(page);
     setupRendererLogCapture(page); // <-- Capture renderer logs to file
 
     // Ensure a clean recent files list
@@ -128,6 +130,7 @@ test.describe('E2E: Simple Request Flow Execution', () => {
   });
 
   test.afterAll(async () => {
+    if (page) await removeMockUpdateRoute(page).catch(() => {});
     if (electronApp) await electronApp.close();
     if (mockServer) await stopHttpbinServer(mockServer);
     try { await fs.rm(simpleFlowPath, { force: true }); } catch {}

--- a/e2e/ui-interactions.e2e.test.js
+++ b/e2e/ui-interactions.e2e.test.js
@@ -8,6 +8,7 @@ import path   from 'node:path';
 import fs     from 'node:fs/promises';
 import fsSync from 'node:fs';
 import { fileURLToPath } from 'url';
+import { setupMockUpdateRoute, removeMockUpdateRoute } from './mockUpdate.js';
 
 /* ───────────── paths / constants ───────────── */
 
@@ -87,6 +88,7 @@ test.describe('E2E: UI Interactions (drag‑drop & graph)', () => {
     page = await app.firstWindow();
     await page.waitForLoadState('domcontentloaded');
     page.setDefaultTimeout(30_000);
+    await setupMockUpdateRoute(page);
     setupRendererLogCapture(page); // <-- Capture renderer logs to file
 
     await pushRecent(page, flowPath);
@@ -103,6 +105,7 @@ test.describe('E2E: UI Interactions (drag‑drop & graph)', () => {
   });
 
   test.afterAll(async () => {
+    if (page) await removeMockUpdateRoute(page).catch(() => {});
     app && await app.close();
     await fs.rm(dataRoot, { recursive: true, force: true }).catch(() => {});
   });


### PR DESCRIPTION
## Summary
- intercept `https://api.github.com/**` in new helper
- apply the helper to all e2e suites

## Testing
- `npm test`
- `npm run e2e` *(fails: E2E: Simple Request Flow Execution > Launch App → Open via Recent → Run → Check Results)*

------
https://chatgpt.com/codex/tasks/task_b_68504c9d759c8320b3baa945914aacc5