### PR TITLE
Add drag reorder for recent flows

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -283,6 +283,11 @@ button:disabled {
     padding-left: 17px;
 }
 
+.flow-list-item.dragging {
+    opacity: 0.5;
+    background-color: var(--medium-bg-color);
+}
+
 .flow-item-actions {
     margin-top: 5px;
     display: flex;


### PR DESCRIPTION
## Summary
- recent flows stay in list when selected
- allow reordering of recent flows with drag & drop

## Testing
- `npm test`
- `npm run e2e` *(fails: redirector.gvt1.com blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68513990d1f48320b5b2e416f09b56ea