### PR TITLE
Improve minimap behavior

### DIFF
--- a/domUtils.js
+++ b/domUtils.js
@@ -34,6 +34,7 @@ export function initializeDOMReferences() {
         zoomOutBtn: document.getElementById('zoom-out-btn'),
         zoomInBtn: document.getElementById('zoom-in-btn'),
         zoomResetBtn: document.getElementById('zoom-reset-btn'),
+        toggleMinimapBtn: document.getElementById('toggle-minimap-btn'),
 
         // Panels relative to Workspace
         variablesPanel: document.querySelector('.variables-panel'),

--- a/eventHandlers.js
+++ b/eventHandlers.js
@@ -57,6 +57,7 @@ export function initializeEventListeners() {
     domRefs.zoomInBtn?.addEventListener('click', () => appState.visualizerComponent?.zoomIn());
     domRefs.zoomOutBtn?.addEventListener('click', () => appState.visualizerComponent?.zoomOut());
     domRefs.zoomResetBtn?.addEventListener('click', () => appState.visualizerComponent?.resetZoom());
+    domRefs.toggleMinimapBtn?.addEventListener('click', () => handleToggleMinimap());
 
     // Info Panel Close Button (Inside Panel) - Explicitly closes
     domRefs.actualInfoOverlayCloseBtn?.addEventListener('click', () => handleToggleInfoOverlay(false));
@@ -237,6 +238,17 @@ export function handleToggleVariablesPanel(forceState = null) {
 
     // No need to update button state here - syncPanelVisibility does it
     syncPanelVisibility(); // Sync button states and potentially other UI elements
+}
+
+export function handleToggleMinimap(forceState = null) {
+    if (!appState.visualizerComponent) return;
+    const willBeVisible = forceState ?? !appState.visualizerComponent.isMinimapVisible();
+    if (willBeVisible) {
+        appState.visualizerComponent.showMinimap();
+    } else {
+        appState.visualizerComponent.hideMinimap();
+    }
+    syncPanelVisibility();
 }
 
 

--- a/flowVisualizer.js
+++ b/flowVisualizer.js
@@ -78,6 +78,7 @@ export class FlowVisualizer {
         this.minimapContent = null;
         this.minimapViewport = null;
         this.minimapScale = 0.15;
+        this.minimapVisible = true;
         this.isMinimapDragging = false;
         this._handleScroll = () => this._updateMinimapViewport();
 
@@ -1459,8 +1460,9 @@ export class FlowVisualizer {
         const scale = this.minimapScale / this.zoomLevel;
         const vw = this.mountPoint.clientWidth * scale;
         const vh = this.mountPoint.clientHeight * scale;
-        const left = this.mountPoint.scrollLeft * this.minimapScale;
-        const top = this.mountPoint.scrollTop * this.minimapScale;
+        const offsetScale = this.minimapScale / this.zoomLevel;
+        const left = this.mountPoint.scrollLeft * offsetScale;
+        const top = this.mountPoint.scrollTop * offsetScale;
         this.minimapViewport.style.width = `${vw}px`;
         this.minimapViewport.style.height = `${vh}px`;
         this.minimapViewport.style.left = `${left}px`;
@@ -1524,5 +1526,32 @@ export class FlowVisualizer {
         const dx = touches[0].clientX - touches[1].clientX;
         const dy = touches[0].clientY - touches[1].clientY;
         return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    showMinimap() {
+        if (this.minimapContainer) {
+            this.minimapContainer.style.display = '';
+            this.minimapVisible = true;
+            this._updateMinimap();
+        }
+    }
+
+    hideMinimap() {
+        if (this.minimapContainer) {
+            this.minimapContainer.style.display = 'none';
+            this.minimapVisible = false;
+        }
+    }
+
+    toggleMinimap() {
+        if (this.minimapVisible) {
+            this.hideMinimap();
+        } else {
+            this.showMinimap();
+        }
+    }
+
+    isMinimapVisible() {
+        return this.minimapVisible;
     }
 }

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
                     <button id="zoom-out-btn" class="btn btn-sm" title="Zoom Out" style="display: none;">-</button>
                     <button id="zoom-in-btn" class="btn btn-sm" title="Zoom In" style="display: none;">+</button>
                     <button id="zoom-reset-btn" class="btn btn-sm" title="Reset Zoom" style="display: none;">100%</button>
+                    <button id="toggle-minimap-btn" class="btn btn-sm" title="Show/Hide Minimap" style="display: none;">Hide Minimap</button>
                 </div>
             </div>
 

--- a/uiUtils.js
+++ b/uiUtils.js
@@ -631,24 +631,28 @@ export function updateViewToggle() {
         if(domRefs.zoomInBtn) domRefs.zoomInBtn.style.display = 'none';
         if(domRefs.zoomOutBtn) domRefs.zoomOutBtn.style.display = 'none';
         if(domRefs.zoomResetBtn) domRefs.zoomResetBtn.style.display = 'none';
+        if(domRefs.toggleMinimapBtn) domRefs.toggleMinimapBtn.style.display = 'none';
         return;
     }
     domRefs.toggleViewBtn.style.display = ''; // Ensure button is visible if flow loaded
     if(domRefs.zoomInBtn) domRefs.zoomInBtn.style.display = appState.currentView === 'node-graph' ? '' : 'none';
     if(domRefs.zoomOutBtn) domRefs.zoomOutBtn.style.display = appState.currentView === 'node-graph' ? '' : 'none';
     if(domRefs.zoomResetBtn) domRefs.zoomResetBtn.style.display = appState.currentView === 'node-graph' ? '' : 'none';
+    if(domRefs.toggleMinimapBtn) domRefs.toggleMinimapBtn.style.display = appState.currentView === 'node-graph' ? '' : 'none';
     if (appState.currentView === 'list-editor') {
         domRefs.toggleViewBtn.textContent = 'Visual View';
         domRefs.toggleViewBtn.title = 'Switch to Node-Graph View (Ctrl+3)';
         // Ensure Info/Vars buttons are potentially visible in list view
         if(domRefs.toggleInfoBtn) domRefs.toggleInfoBtn.style.display = '';
         if(domRefs.toggleVariablesBtn) domRefs.toggleVariablesBtn.style.display = '';
+        if(appState.visualizerComponent) appState.visualizerComponent.hideMinimap();
     } else { // Node-graph view
         domRefs.toggleViewBtn.textContent = 'Editor View';
         domRefs.toggleViewBtn.title = 'Switch to List/Editor View (Ctrl+3)';
         // Ensure Info/Vars buttons are potentially visible in graph view
         if(domRefs.toggleInfoBtn) domRefs.toggleInfoBtn.style.display = '';
         if(domRefs.toggleVariablesBtn) domRefs.toggleVariablesBtn.style.display = '';
+        if(appState.visualizerComponent) appState.visualizerComponent.showMinimap();
     }
 }
 
@@ -656,6 +660,7 @@ export function updateViewToggle() {
 export function syncPanelVisibility() {
     const toggleInfoBtn = domRefs.toggleInfoBtn;
     const toggleVariablesBtn = domRefs.toggleVariablesBtn;
+    const toggleMinimapBtn = domRefs.toggleMinimapBtn;
 
     // --- Update Info Panel Toggle Button ---
     if (toggleInfoBtn) {
@@ -675,10 +680,20 @@ export function syncPanelVisibility() {
         toggleVariablesBtn.querySelector('.btn-text').textContent = appState.isVariablesPanelVisible ? 'Hide Variables' : 'Show Variables';
     }
 
+    if (toggleMinimapBtn) {
+        const isVisible = appState.visualizerComponent?.isMinimapVisible() ?? false;
+        toggleMinimapBtn.classList.toggle('active', isVisible);
+        toggleMinimapBtn.textContent = isVisible ? 'Hide Minimap' : 'Show Minimap';
+    }
+
     // Show/hide the toggle buttons themselves based on whether a flow is loaded
     const shouldShowButtons = !!appState.currentFlowModel;
     if (toggleInfoBtn) toggleInfoBtn.style.display = shouldShowButtons ? '' : 'none';
     if (toggleVariablesBtn) toggleVariablesBtn.style.display = shouldShowButtons ? '' : 'none';
+    if (toggleMinimapBtn) {
+        const shouldShow = shouldShowButtons && appState.currentView === 'node-graph';
+        toggleMinimapBtn.style.display = shouldShow ? '' : 'none';
+    }
 }
 
 /** Clears all runtime-related status classes from steps in the list view */


### PR DESCRIPTION
## Summary
- add minimap toggle button and DOM reference
- handle minimap toggling in event handlers
- keep minimap hidden outside visual editor
- fix minimap viewport scaling
- expose methods on `FlowVisualizer` for showing/hiding minimap

## Testing
- `npm test`
- `npm run e2e` *(fails: locator.hover TimeoutError)*

------
https://chatgpt.com/codex/tasks/task_b_6851820057488320b1edb72d4045aaff