### PR TITLE
Improve minimap and pointer panning

### DIFF
--- a/__tests__/flowVisualizer.test.js
+++ b/__tests__/flowVisualizer.test.js
@@ -200,10 +200,10 @@ describe('FlowVisualizer', () => {
         await waitForVisualizerRender();
         const initialScrollLeft = visualizer.mountPoint.scrollLeft;
         const initialScrollTop = visualizer.mountPoint.scrollTop;
-        const mouseDownEvent = new MouseEvent('mousedown', { bubbles: true, clientX: 100, clientY: 100, button: 0 });
-        visualizer.canvas.dispatchEvent(mouseDownEvent);
-        const mouseMoveEvent = new MouseEvent('mousemove', { bubbles: true, clientX: 50, clientY: 70 });
-        document.dispatchEvent(mouseMoveEvent);
+        const pointerDownEvent = new MouseEvent('pointerdown', { bubbles: true, clientX: 100, clientY: 100, button: 0 });
+        visualizer.canvas.dispatchEvent(pointerDownEvent);
+        const pointerMoveEvent = new MouseEvent('pointermove', { bubbles: true, clientX: 50, clientY: 70 });
+        document.dispatchEvent(pointerMoveEvent);
         expect(visualizer.mountPoint.style.cursor).toBe('grabbing');
         const maxLeft = Math.max(0, visualizer.mountPoint.scrollWidth - visualizer.mountPoint.clientWidth);
         const maxTop = Math.max(0, visualizer.mountPoint.scrollHeight - visualizer.mountPoint.clientHeight);
@@ -211,8 +211,8 @@ describe('FlowVisualizer', () => {
         const expectedTop = Math.max(0, Math.min(maxTop, initialScrollTop - (70 - 100)));
         expect(visualizer.mountPoint.scrollLeft).toBe(expectedLeft);
         expect(visualizer.mountPoint.scrollTop).toBe(expectedTop);
-        const mouseUpEvent = new MouseEvent('mouseup', {});
-        document.dispatchEvent(mouseUpEvent);
+        const pointerUpEvent = new MouseEvent('pointerup', {});
+        document.dispatchEvent(pointerUpEvent);
         expect(visualizer.mountPoint.style.cursor).toBe('grab');
     });
 

--- a/flowVisualizer.js
+++ b/flowVisualizer.js
@@ -81,6 +81,7 @@ export class FlowVisualizer {
         this.minimapVisible = false;
         this.isMinimapDragging = false;
         this._handleScroll = () => this._updateMinimapViewport();
+        this._minimapFrame = null;
 
         // Debounce resize handler
         this.resizeObserver = null;
@@ -149,7 +150,7 @@ export class FlowVisualizer {
 
     /** Binds essential event listeners for panning and potential resizing. */
     _bindBaseListeners() {
-        this.mountPoint.addEventListener('mousedown', this._handleMouseDown);
+        this.mountPoint.addEventListener('pointerdown', this._handlePanStart);
         this.mountPoint.addEventListener('wheel', this._handleWheel, { passive: false });
         this.mountPoint.addEventListener('touchstart', this._handleTouchStart, { passive: false });
         this.mountPoint.addEventListener('touchmove', this._handleTouchMove, { passive: false });
@@ -870,13 +871,6 @@ export class FlowVisualizer {
         }
     }
 
-    _handleMouseDown = (e) => {
-        // Pan only if clicking the background (mountPoint or canvas directly)
-        if (e.button === PAN_BUTTON && (e.target === this.mountPoint || e.target === this.canvas)) {
-            this._handlePanStart(e);
-        }
-    }
-
     _handleWheel = (e) => {
         if (!e.ctrlKey) return;
         e.preventDefault();
@@ -885,7 +879,8 @@ export class FlowVisualizer {
     }
     // --- End Bound Handlers ---
 
-    _handlePanStart(e) {
+    _handlePanStart = (e) => {
+        e.preventDefault();
         this.isPanning = true;
         this.panStartX = e.clientX;
         this.panStartY = e.clientY;
@@ -893,12 +888,11 @@ export class FlowVisualizer {
         this.scrollTopStart = this.mountPoint.scrollTop;
         this.mountPoint.style.cursor = 'grabbing';
         this.mountPoint.style.userSelect = 'none'; // Prevent text selection during pan
-        document.addEventListener('mousemove', this._handleMouseMove);
-        document.addEventListener('mouseup', this._handleMouseUp);
-        e.preventDefault();
+        document.addEventListener('pointermove', this._handlePanMove);
+        document.addEventListener('pointerup', this._handlePanEnd);
     }
 
-    _handlePanMove(e) {
+    _handlePanMove = (e) => {
         if (!this.isPanning) return;
         const dx = e.clientX - this.panStartX;
         const dy = e.clientY - this.panStartY;
@@ -906,13 +900,12 @@ export class FlowVisualizer {
         this._updateMinimapViewport();
     }
 
-    _handlePanEnd(e) {
+    _handlePanEnd = (e) => {
         this.isPanning = false;
         this.mountPoint.style.cursor = 'grab';
         this.mountPoint.style.userSelect = ''; // Re-enable text selection
-        document.removeEventListener('mousemove', this._handleMouseMove);
-        document.removeEventListener('mouseup', this._handleMouseUp);
-        this.mountPoint?.removeEventListener('wheel', this._handleWheel);
+        document.removeEventListener('pointermove', this._handlePanMove);
+        document.removeEventListener('pointerup', this._handlePanEnd);
     }
 
     _handleNodeMouseDown = (e) => { // Arrow function binds 'this'
@@ -1322,9 +1315,11 @@ export class FlowVisualizer {
         // Remove dynamically added document listeners
         document.removeEventListener('mousemove', this._handleMouseMove);
         document.removeEventListener('mouseup', this._handleMouseUp);
+        document.removeEventListener('pointermove', this._handlePanMove);
+        document.removeEventListener('pointerup', this._handlePanEnd);
 
         // Remove listeners attached to the mount point itself
-        this.mountPoint?.removeEventListener('mousedown', this._handleMouseDown);
+        this.mountPoint?.removeEventListener('pointerdown', this._handlePanStart);
         this.mountPoint?.removeEventListener('wheel', this._handleWheel);
         this.mountPoint?.removeEventListener('touchstart', this._handleTouchStart);
         this.mountPoint?.removeEventListener('touchmove', this._handleTouchMove);
@@ -1474,6 +1469,14 @@ export class FlowVisualizer {
     }
 
     _updateMinimapViewport() {
+        if (this._minimapFrame) return;
+        this._minimapFrame = requestAnimationFrame(() => {
+            this._minimapFrame = null;
+            this._doMinimapViewport();
+        });
+    }
+
+    _doMinimapViewport() {
         if (!this.minimapViewport || !this.canvas) return;
         const scale = this.minimapScale;
         const vw = (this.mountPoint.clientWidth / this.zoomLevel) * scale;
@@ -1512,8 +1515,8 @@ export class FlowVisualizer {
         const x = (e.clientX - rect.left) / this.minimapScale;
         const y = (e.clientY - rect.top) / this.minimapScale;
         this._applyScroll(
-            x - this.mountPoint.clientWidth / 2,
-            y - this.mountPoint.clientHeight / 2
+            (x * this.zoomLevel) - this.mountPoint.clientWidth  / 2,
+            (y * this.zoomLevel) - this.mountPoint.clientHeight / 2
         );
         this._updateMinimapViewport();
     }

--- a/styles.css
+++ b/styles.css
@@ -601,6 +601,23 @@ button:disabled {
     z-index: 1000;
 }
 
+/* Minimap fade-in & Retina crispness */
+.visualizer-minimap {
+    transition: opacity .25s ease;
+    opacity: 0;
+}
+.visualizer-minimap[style*="display: none"] {
+    opacity: 0;
+}
+.visualizer-minimap:not([style*="display: none"]) {
+    opacity: 1;
+}
+
+/* Sharper lines inside miniature SVG */
+.visualizer-minimap svg {
+    shape-rendering: crispEdges;
+}
+
 .minimap-viewport {
     box-sizing: border-box;
     background: rgba(59,130,246,0.2);


### PR DESCRIPTION
## Summary
- improve minimap viewport calculations and throttling
- update pointer handlers for canvas panning
- keep wheel zoom active after drag
- add minimap fade-in CSS
- update tests for pointer events

## Testing
- `npm test`
- `npm run e2e` *(fails: cannot reach redirector.gvt1.com)*

------
https://chatgpt.com/codex/tasks/task_b_6851a7cea9d483208fde538cdbd8be67