### PR TITLE
Fix minimap live update and UX

### DIFF
--- a/eventHandlers.js
+++ b/eventHandlers.js
@@ -180,6 +180,11 @@ export function initializeEventListeners() {
             e.preventDefault();
             domRefs.toggleViewBtn?.click(); // Simulate click on the button
         }
+
+        if (e.key.toLowerCase() === 'm' && appState.currentView === 'node-graph') {
+            e.preventDefault();
+            domRefs.toggleMinimapBtn?.click();
+        }
     });
 
     logger.info("All core event listeners initialized.");

--- a/styles.css
+++ b/styles.css
@@ -603,7 +603,8 @@ button:disabled {
 
 /* Minimap fade-in & Retina crispness */
 .visualizer-minimap {
-    transition: opacity .25s ease;
+    transition: opacity .25s ease, transform .15s ease;
+    cursor: pointer;
     opacity: 0;
 }
 .visualizer-minimap[style*="display: none"] {
@@ -616,6 +617,12 @@ button:disabled {
 /* Sharper lines inside miniature SVG */
 .visualizer-minimap svg {
     shape-rendering: crispEdges;
+    vector-effect: non-scaling-stroke;   /* keep strokes 1 px regardless of scale */
+}
+
+.visualizer-minimap path {
+    stroke: var(--border-color-dark);
+    stroke-width: 1;
 }
 
 .minimap-viewport {


### PR DESCRIPTION
## Summary
- throttle heavy minimap redraw during dragging
- refresh minimap at drag end
- strip `stroke` on cloned SVG paths to avoid black artefact
- tweak minimap styles for crisp scalable preview
- update minimap cursor behavior and double‑click recentering
- add keyboard shortcut **M** to toggle minimap

## Testing
- `npm test`
- `npm run e2e` *(fails: E2E: Comprehensive Flow Execution – Run flow & verify a few key results)*

------
https://chatgpt.com/codex/tasks/task_b_6851c07e4d18832086be113309a4e0ab