### PR TITLE
Fix width and overflow in UI

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -443,8 +443,13 @@ button:disabled {
     margin-bottom: 18px;
 }
 .flow-info-overlay textarea {
+    width: 100%;
     min-height: 60px;
     resize: vertical;
+}
+
+.flow-info-overlay input[type="text"] {
+    width: 100%;
 }
 .flow-info-overlay .collapsible-header {
   display: flex;
@@ -978,6 +983,7 @@ button:disabled {
 }
 .result-extracted-values li {
     margin-bottom: 4px;
+    overflow-wrap: anywhere;
 }
 .result-extracted-values li:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Summary
- make info overlay text fields expand to container width
- prevent overflow of long extracted values

## Testing
- `npm test`
- `npm run e2e` *(fails: waiting for locator '.flow-step[data-step-id="step_e2e_1_get_ip"]')*

------
https://chatgpt.com/codex/tasks/task_b_6851ddff61808320a6c566b76ed65ab8