### PR TITLE
Prepare v1.1.1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlowRunner 
 
-![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)
+![Version](https://img.shields.io/badge/version-1.1.1-blue.svg)
 <!-- Optional: Add build status/license badges here if desired -->
 <!-- [![Build Status](YOUR_BUILD_BADGE_URL)](YOUR_BUILD_URL) -->
 
@@ -16,6 +16,9 @@
 ---
 
 ## Release Notes / Changelog
+
+### v1.1.1 (June 2025)
+- Documentation updates and minor improvements.
 
 ### v1.1.0 (May 2025)
 - **Continuous Flow Runner:**
@@ -88,17 +91,17 @@ This tool is particularly useful for:
 ## Prerequisites
 
 *   Windows (x64) or macOS (Apple Silicon / arm64).
-*   The appropriate FlowRunner installer package downloaded from the [v1.1.0 Release Page](https://github.com/Radware/FlowRunner/releases/tag/v1.1.0) (or latest release).
+*   The appropriate FlowRunner installer package downloaded from the [v1.1.1 Release Page](https://github.com/Radware/FlowRunner/releases/tag/v1.1.1) (or latest release).
 *   Network access is required *only* when executing flows that contain 'API Request' steps which need to reach external endpoints. Flow authoring, saving, loading, and visualization can be done offline.
 
 ## Installation
 
 1.  **Download the Correct Installer:**
     *   Go to the [FlowRunner Releases Page](https://github.com/Radware/FlowRunner/releases) on GitHub.
-    *   Find the latest release (e.g., v1.1.0).
+    *   Find the latest release (e.g., v1.1.1).
     *   Under **Assets**:
-        *   For **Windows (x64)**, download `FlowRunnerSetup-x64-win-1.1.0.zip`. Unzip the file to find the `Setup.exe`.
-        *   For **macOS (Apple Silicon / arm64)**, download `FlowRunnerSetup-arm64-mac-1.1.0.dmg`.
+        *   For **Windows (x64)**, download `FlowRunnerSetup-x64-win-1.1.1.zip`. Unzip the file to find the `Setup.exe`.
+        *   For **macOS (Apple Silicon / arm64)**, download `FlowRunnerSetup-arm64-mac-1.1.1.dmg`.
 2.  **Install on Windows:**
     *   Double-click the extracted `Setup.exe` file.
     *   The installation will proceed silently in the background (using Squirrel.Windows). It typically installs to your `AppData\Local\FlowRunner` folder.

--- a/config.js
+++ b/config.js
@@ -7,5 +7,5 @@ export const DEFAULT_REQUEST_DELAY = 500; // Keep this
 export const LOG_LEVEL = 'info'; // Possible values: 'debug', 'info', 'warn', 'error'
 
 // --- Update Notification Config ---
-export const CURRENT_VERSION = '1.1.0'; // Update as needed for your release
+export const CURRENT_VERSION = '1.1.1'; // Update as needed for your release
 export const GITHUB_RELEASES_API = 'https://api.github.com/repos/Radware/FlowRunner/releases/latest';

--- a/development_tasks.md
+++ b/development_tasks.md
@@ -48,7 +48,7 @@ This document breaks down the features and improvements planned in the roadmap i
 
 ---
 
-## v1.1.0 Tasks: Quality, Testing & Refinement
+## v1.1.1 Tasks: Quality, Testing & Refinement
 
 *   **Recent Files Management:**
     *   [x] Design UI interaction for removing a recent file (e.g., 'X' button, right-click context menu).

--- a/e2e/mockUpdate.js
+++ b/e2e/mockUpdate.js
@@ -4,8 +4,8 @@ export async function setupMockUpdateRoute(page) {
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify({
-                tag_name: 'v1.1.0',
-                html_url: 'https://example.com/release/v1.1.0'
+                tag_name: 'v1.1.1',
+                html_url: 'https://example.com/release/v1.1.1'
             })
         });
     });

--- a/help.html
+++ b/help.html
@@ -221,7 +221,7 @@
                     on the FlowRunner GitHub repository.
                 </p>
                  <p>
-                    Application Version: 1.1.0 <!-- Update this manually or find a way to inject it -->
+                    Application Version: 1.1.1 <!-- Update this manually or find a way to inject it -->
                  </p>
             </section>
         </main>

--- a/main.js
+++ b/main.js
@@ -76,7 +76,7 @@ async function checkUnsavedChanges() {
 // --- Application Information ---
 const appName = 'FlowRunner';
 // Try reading version from package.json
-let appVersion = '1.1.0'; // Default version (Ensure this matches your actual package.json)
+let appVersion = '1.1.1'; // Default version (Ensure this matches your actual package.json)
 try {
     const packageJsonPath = path.join(__dirname, 'package.json');
     const packageJsonContent = await fs.readFile(packageJsonPath, 'utf-8');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flowrunner",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flowrunner",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowrunner",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "API Flow Creation and Visualization Tool",
   "main": "main.js",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump version numbers to 1.1.1 across config and docs
- update help page and README references
- adjust development tasks header

## Testing
- `npm test`
- `npm run e2e` *(fails: Run flow & verify a few key results)*

------
https://chatgpt.com/codex/tasks/task_b_6851e569a1548320b69f62eba4226c59