### PR TITLE
Update docs for new minimap and variable options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ This tool is particularly useful for:
     *   **Loop:** Repeat steps for each item in an array.
 *   **Dual Views:** Work the way you prefer:
     *   **List/Editor View:** A detailed list of steps with a dedicated panel for configuration and drag-and-drop reordering.
-    *   **Node-Graph View:** An interactive visual graph showing the flow structure and connections. Drag nodes to arrange the layout.
+    *   **Node-Graph View:** An interactive visual graph showing the flow structure and connections. Drag nodes to arrange the layout. Use zoom controls and an optional minimap for easier navigation of large flows.
 *   **Variable Management:** Handle dynamic data effectively:
-    *   Define **Global Headers** and **Static Variables** for the entire flow.
+    *   Define **Global Headers** and **Static Variables** for the entire flow. Variables can be typed as String, Number, Boolean, or JSON to better control how values are parsed and substituted.
     *   **Extract** data from API responses (like status code, headers, or values from the body using JSON paths) into variables.
     *   **Substitute** variables (`{{variableName}}`) into URLs, headers, request bodies, condition values, etc.
     *   Use the **`{{…}}`** helper button to easily insert defined variable names.
@@ -77,15 +77,16 @@ This tool is particularly useful for:
     *   Configure a delay between steps during full runs for better observation.
     *   View **real-time highlighting** of the currently executing or completed step in both views.
     *   Monitor progress in the detailed **Results Panel**, showing each step's status, output, errors, and extraction warnings.
+    *   Use the search box and status filter to narrow displayed results, and copy any step's output to the clipboard.
 *   **Local Flow Management:** Work entirely offline:
     *   Create new flows from a template.
     *   **Save** flows to your local computer as `.flow.json` files.
     *   **Load** flows from your local files.
-    *   Access **Recent Files** quickly from the sidebar.
+    *   Access **Recent Files** quickly from the sidebar and reorder them via drag-and-drop.
     *   **Clone** existing flows to create variations easily.
 *   **User Interface:**
     *   Collapsible Sidebar and Runner panels to maximize workspace.
-    *   Clear indication of unsaved changes.
+    *   Clear indication of unsaved changes, with the Save button highlighted when edits are pending.
     *   Configurable visual layout for the Node-Graph view.
 
 ## Prerequisites
@@ -164,7 +165,7 @@ Click the **"Info ▼"** button in the workspace header to open the Flow Info ov
 *   **Flow Name:** A descriptive name for your flow.
 *   **Description:** Optional details about the flow's purpose.
 *   **Global Headers:** Define HTTP headers (Key-Value pairs) that will be automatically added to *all* 'API Request' steps in this flow. Headers defined within individual steps will override global headers with the same key.
-*   **Flow Variables:** Define static variables (Key-Value pairs) that are available throughout the flow's execution. These are useful for configuration values or initial setup data. Variable names should be valid identifiers (letters, numbers, `_`, starting with a letter or `_`). Values may contain JSON arrays or objects for loops or complex data.
+*   **Flow Variables:** Define static variables (Key-Value pairs) that are available throughout the flow's execution. Each variable can be typed as String, Number, Boolean, or JSON. Variable names should be valid identifiers (letters, numbers, `_`, starting with a letter or `_`). Values may contain JSON arrays or objects for loops or complex data.
 
 Changes here mark the flow as unsaved. Close the overlay by clicking the **"Info ▲"** button again.
 

--- a/help.html
+++ b/help.html
@@ -43,7 +43,7 @@
                     <h3>Sidebar (Left)</h3>
                     <ul>
                         <li><strong>Branding:</strong> Application logo and name.</li>
-                        <li><strong>Recent Flows:</strong> Lists recently opened/saved <code>.flow.json</code> files. Click to open. Use the '✕' button to remove an entry from this list.</li>
+                        <li><strong>Recent Flows:</strong> Lists recently opened/saved <code>.flow.json</code> files. Drag to reorder the list. Use the '✕' button to remove an entry.</li>
                         <li><strong>Actions:</strong>
                             <ul>
                                 <li><strong>+ New Flow:</strong> Creates a blank flow.</li>
@@ -59,7 +59,7 @@
                         <li><strong>Header:</strong>
                             <ul>
                                 <li><strong>Title:</strong> Shows the current flow name (with '*' if unsaved).</li>
-                                <li><strong>File Controls:</strong> Save, Save As, Cancel (revert changes), Close. Enabled based on flow state and unsaved changes.</li>
+                                <li><strong>File Controls:</strong> Save, Save As, Cancel (revert changes), Close. The Save button highlights when unsaved changes exist.</li>
                                 <li><strong>View Controls:</strong>
                                     <ul>
                                         <li><strong>Toggle View:</strong> Switches between List/Editor and Node-Graph views.</li>
@@ -85,7 +85,7 @@
                             </ul>
                         </li>
                         <li><strong>Status Messages:</strong> Shows brief messages about runner state (starting, stopped, errors).</li>
-                        <li><strong>Execution Results:</strong> A detailed log of each step execution, including status, output/error details, and extraction warnings.</li>
+                        <li><strong>Execution Results:</strong> A detailed log of each step execution, including status, output/error details, and extraction warnings. Use the search box and status filter to narrow the list, and click the copy icon to copy step output.</li>
                     </ul>
                 </div>
             </section>
@@ -98,7 +98,7 @@
                     <ul>
                         <li><strong>Name & Description:</strong> Basic identification.</li>
                         <li><strong>Global Headers:</strong> Headers automatically added to all API Request steps (can be overridden by step-specific headers).</li>
-                        <li><strong>Flow Variables (Static):</strong> Key-value pairs defined once and available throughout the flow execution context. Useful for configuration like base URLs or static tokens. Values may be JSON arrays or objects for loops or complex data.</li>
+                        <li><strong>Flow Variables (Static):</strong> Key-value pairs defined once and available throughout the flow execution context. Each variable can be typed as String, Number, Boolean, or JSON. Values may be JSON arrays or objects for loops or complex data.</li>
                     </ul>
                 </div>
                  <div class="subsection">
@@ -130,7 +130,7 @@
                     <h3>Views</h3>
                      <ul>
                         <li><strong>List/Editor View:</strong> Default view showing steps hierarchically. Best for detailed configuration using the step editor panel. Supports step reordering via drag-and-drop using the ☰ handle.</li>
-                        <li><strong>Node-Graph View:</strong> Visual representation of the flow structure with connecting lines. Useful for understanding branching and looping. Pan by dragging the background. Drag nodes to rearrange the visual layout (positions are saved with the flow). Select nodes by clicking them.</li>
+                        <li><strong>Node-Graph View:</strong> Visual representation of the flow structure with connecting lines. Useful for understanding branching and looping. Pan by dragging the background. Drag nodes to rearrange the visual layout (positions are saved with the flow). Select nodes by clicking them. Use zoom controls and the minimap to navigate large graphs.</li>
                     </ul>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- document new minimap navigation
- describe typed global variables and other features
- mention result search, copy button, and reorderable recent files

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_6851edd4baa083209b91977c73c98a8a