### PR TITLE
Add minimap refresh hook and enhance styles

### DIFF
--- a/flowVisualizer.js
+++ b/flowVisualizer.js
@@ -1655,3 +1655,8 @@ export class FlowVisualizer {
         return this.minimapVisible;
     }
 }
+
+// tiny helper so external code (tests, Cypress, etc.) can force a minimap redraw
+FlowVisualizer.prototype.__forceMinimapRefresh = function () {
+    this._updateMinimap();
+};

--- a/styles.css
+++ b/styles.css
@@ -1670,3 +1670,16 @@ body.flow-step-dragging { cursor: grabbing !important; }
     margin-top: 15px;
     text-decoration: none;
 }
+
+/* --- FlowVisualizer minimap enhancements --- */
+.visualizer-minimap rect {
+    shape-rendering: crispEdges;            /* pixel-perfect hairlines       */
+}
+
+.visualizer-minimap rect:hover {
+    stroke-width: 2;                        /* hint the user can click / pan */
+}
+
+.visualizer-canvas.nodes-dragging {
+    cursor: grabbing !important;            /* keep hand cursor on drag      */
+}


### PR DESCRIPTION
## Summary
- add a public `__forceMinimapRefresh` hook on FlowVisualizer
- enhance minimap CSS for crisp edges and better dragging

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_68525ef0dbe08320a5b27b5cdba2c1e0