### PR TITLE
Add CSS styling for minimap node frames

### DIFF
--- a/flowVisualizer.js
+++ b/flowVisualizer.js
@@ -1475,14 +1475,13 @@ export class FlowVisualizer {
 
     _addMiniRect(x, y, w, h) {
         const r = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+        r.classList.add('minimap-node-frame');          // NEW — for CSS styling
         r.setAttribute('x', x);
         r.setAttribute('y', y);
-        r.setAttribute('width', Math.max(2, w));   // avoid 0-size artefacts
+        r.setAttribute('width', Math.max(2, w));        // avoid 0-size artefacts
         r.setAttribute('height', Math.max(2, h));
-        r.setAttribute('fill', 'none');
-        r.setAttribute('stroke', '#2563eb');       // blue-500 – easy to see
-        r.setAttribute('stroke-width', '1.25');
-        r.setAttribute('vector-effect','non-scaling-stroke');
+        r.setAttribute('fill', 'none');                  // appearance now in CSS
+        r.setAttribute('vector-effect', 'non-scaling-stroke');
         return r;
     }
 

--- a/styles.css
+++ b/styles.css
@@ -1680,6 +1680,18 @@ body.flow-step-dragging { cursor: grabbing !important; }
     stroke-width: 2;                        /* hint the user can click / pan */
 }
 
+.visualizer-minimap .minimap-node-frame {
+    stroke: #2563eb;        /* blue-500 – easy to spot           */
+    stroke-width: 2.25;     /* thicker than connector hairlines  */
+    filter: drop-shadow(0 0 1px #2563eb);          /* light glow */
+    vector-effect: non-scaling-stroke;               /* stays ≥2 px no matter zoom */
+}
+
+.visualizer-minimap .minimap-node-frame.highlighted {
+    stroke: #ea580c;        /* optional – orange when a node is  */
+    filter: drop-shadow(0 0 2px #ea580c);   /*   hovered / selected        */
+}
+
 .visualizer-canvas.nodes-dragging {
     cursor: grabbing !important;            /* keep hand cursor on drag      */
 }


### PR DESCRIPTION
## Summary
- draw minimap node rectangles with a `minimap-node-frame` class
- style minimap node frames entirely in CSS

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_685281cd1af88320b45e0e8b51f21eb1