### PR TITLE
Fix extracted variable copy button layout

### DIFF
--- a/__tests__/runnerInterface.test.js
+++ b/__tests__/runnerInterface.test.js
@@ -46,4 +46,29 @@ describe('renderResultItemContent', () => {
         btn.dispatchEvent(new Event('click'));
         expect(writeMock).toHaveBeenCalledWith('hello');
     });
+
+    test('copy button for extracted value writes to clipboard', () => {
+        const writeMock = jest.fn();
+        Object.assign(navigator, { clipboard: { writeText: writeMock } });
+        const li = document.createElement('li');
+        const data = {
+            stepName: 'Req1',
+            stepId: 'r1',
+            status: 'success',
+            output: null,
+            error: null,
+            extractionFailures: [],
+            extractedValues: { token: 'abc' }
+        };
+        renderResultItemContent(li, data);
+        const btn = li.querySelector('.result-extracted-values .copy-btn');
+        expect(btn).not.toBeNull();
+        jest.useFakeTimers();
+        btn.dispatchEvent(new Event('click'));
+        expect(writeMock).toHaveBeenCalledWith('abc');
+        expect(btn.textContent).toBe('Copied!');
+        jest.advanceTimersByTime(1000);
+        expect(btn.textContent).toBe('Copy');
+        jest.useRealTimers();
+    });
 });

--- a/e2e/flow-execution.e2e.test.js
+++ b/e2e/flow-execution.e2e.test.js
@@ -425,10 +425,25 @@ test.describe('E2E: Comprehensive Flow Execution', () => {
 
     const expectedRaw = await step1ResultLocator.locator('.result-body pre').textContent();
 
-    await step1ResultLocator.locator('.copy-btn').click();
+    await step1ResultLocator.locator('.result-body .copy-btn').click();
 
     const copied = await page.evaluate(() => window.__copied);
     expect(copied).toBe(expectedRaw);
+
+    await page.evaluate(() => { window.__copied = null; });
+    const extractedVal = await step1ResultLocator.locator('.result-extracted-values li span.extracted-value').first().textContent();
+    const varCopyBtn = step1ResultLocator.locator('.result-extracted-values .copy-btn').first();
+    await varCopyBtn.click();
+    const copiedVar = await page.evaluate(() => window.__copied);
+    expect(copiedVar).toBe(extractedVal);
+    await expect(varCopyBtn).toHaveText('Copied!');
+    await page.waitForTimeout(1100);
+    await expect(varCopyBtn).toHaveText('Copy');
+
+    await page.fill('#results-search', 'userAgent');
+    await page.waitForTimeout(200);
+    await expect(step1ResultLocator).toBeVisible();
+    await page.fill('#results-search', '');
 
     const step3Failures = page.locator('.result-item[data-step-id="step_e2e_3_post_data"] .result-extraction-failures');
     await expect(step3Failures).toBeVisible();

--- a/styles.css
+++ b/styles.css
@@ -984,9 +984,16 @@ button:disabled {
 .result-extracted-values li {
     margin-bottom: 4px;
     overflow-wrap: anywhere;
+    display: flex;
+    align-items: center;
 }
 .result-extracted-values li:last-child {
     margin-bottom: 0;
+}
+.result-extracted-values li .copy-btn {
+    margin-top: 0;
+    margin-left: auto;
+    float: none;
 }
 .result-extracted-values code {
     background-color: #dbeafe;


### PR DESCRIPTION
## Summary
- place extracted value copy buttons inside the blue container
- show temporary "Copied!" feedback when clicking
- update unit and e2e tests for new behaviour

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_68528fa7ed788320a7ba8f4b7789dba7