### PR TITLE
Fix extracted variable copy button layout

### DIFF
--- a/__tests__/runnerInterface.test.js
+++ b/__tests__/runnerInterface.test.js
@@ -46,4 +46,29 @@ describe('renderResultItemContent', () => {
         btn.dispatchEvent(new Event('click'));
         expect(writeMock).toHaveBeenCalledWith('hello');
     });
+
+    test('copy button for extracted value writes to clipboard', () => {
+        const writeMock = jest.fn();
+        Object.assign(navigator, { clipboard: { writeText: writeMock } });
+        const li = document.createElement('li');
+        const data = {
+            stepName: 'Req1',
+            stepId: 'r1',
+            status: 'success',
+            output: null,
+            error: null,
+            extractionFailures: [],
+            extractedValues: { token: 'abc' }
+        };
+        renderResultItemContent(li, data);
+        const btn = li.querySelector('.result-extracted-values .copy-btn');
+        expect(btn).not.toBeNull();
+        jest.useFakeTimers();
+        btn.dispatchEvent(new Event('click'));
+        expect(writeMock).toHaveBeenCalledWith('abc');
+        expect(btn.textContent).toBe('Copied!');
+        jest.advanceTimersByTime(1000);
+        expect(btn.textContent).toBe('Copy');
+        jest.useRealTimers();
+    });
 });

--- a/e2e/flow-execution.e2e.test.js
+++ b/e2e/flow-execution.e2e.test.js
@@ -425,10 +425,25 @@ test.describe('E2E: Comprehensive Flow Execution', () => {
 
     const expectedRaw = await step1ResultLocator.locator('.result-body pre').textContent();
 
-    await step1ResultLocator.locator('.copy-btn').click();
+    await step1ResultLocator.locator('.result-body .copy-btn').click();
 
     const copied = await page.evaluate(() => window.__copied);
     expect(copied).toBe(expectedRaw);
+
+    await page.evaluate(() => { window.__copied = null; });
+    const extractedVal = await step1ResultLocator.locator('.result-extracted-values li span.extracted-value').first().textContent();
+    const varCopyBtn = step1ResultLocator.locator('.result-extracted-values .copy-btn').first();
+    await varCopyBtn.click();
+    const copiedVar = await page.evaluate(() => window.__copied);
+    expect(copiedVar).toBe(extractedVal);
+    await expect(varCopyBtn).toHaveText('Copied!');
+    await page.waitForTimeout(1100);
+    await expect(varCopyBtn).toHaveText('Copy');
+
+    await page.fill('#results-search', 'userAgent');
+    await page.waitForTimeout(200);
+    await expect(step1ResultLocator).toBeVisible();
+    await page.fill('#results-search', '');
 
     const step3Failures = page.locator('.result-item[data-step-id="step_e2e_3_post_data"] .result-extraction-failures');
     await expect(step3Failures).toBeVisible();

--- a/runnerInterface.js
+++ b/runnerInterface.js
@@ -6,7 +6,7 @@ import { showMessage, clearListViewHighlights, highlightStepInList, updateDefine
 import { findStepById, escapeHTML } from './flowCore.js'; // findStepById needed for result rendering
 import { logger } from './logger.js';
 
-function computeSearchText(stepName, output, error) {
+function computeSearchText(stepName, output, error, extractedValues) {
     const parts = [stepName];
     if (output !== null && output !== undefined) {
         try {
@@ -15,6 +15,16 @@ function computeSearchText(stepName, output, error) {
     }
     if (error) {
         parts.push(typeof error === 'string' ? error : error.message || '');
+    }
+    if (extractedValues && Object.keys(extractedValues).length > 0) {
+        for (const [name, val] of Object.entries(extractedValues)) {
+            parts.push(name);
+            try {
+                parts.push(typeof val === 'string' ? val : JSON.stringify(val));
+            } catch (_) {
+                parts.push(String(val));
+            }
+        }
     }
     return parts.join(' ').toLowerCase();
 }
@@ -361,7 +371,7 @@ export function addResultEntry(step, status = 'pending', executionPath = [], out
     li.dataset.resultIndex = resultIndex;
 
     logger.debug(`[DOM UPDATE] addResultEntry: Adding li for stepId=${stepId}, status=${status}, index=${resultIndex}`);
-    const searchText = computeSearchText(step.name || 'Unnamed Step', output, error);
+    const searchText = computeSearchText(step.name || 'Unnamed Step', output, error, extractedValues);
     const resultData = {
         stepId: stepId,
         stepName: step.name || 'Unnamed Step',
@@ -399,7 +409,7 @@ export function updateResultEntry(index, status, output, error, extractionFailur
     resultData.error = error;
     resultData.extractionFailures = extractionFailures || [];
     resultData.extractedValues = extractedValues || {};
-    resultData.searchText = computeSearchText(resultData.stepName, output, error);
+    resultData.searchText = computeSearchText(resultData.stepName, output, error, extractedValues);
 
     const li = domRefs.runnerResultsList.querySelector(`li.result-item[data-result-index="${index}"]`);
     if (!li) {
@@ -468,7 +478,8 @@ export function renderResultItemContent(listItem, resultData) {
             } catch (e) {
                 valString = String(val);
             }
-            return `<li><code>${escapeHTML(name)}</code>: ${escapeHTML(valString)}</li>`;
+            const escapedVal = escapeHTML(valString);
+            return `<li><div><code>${escapeHTML(name)}</code>: <span class="extracted-value">${escapedVal}</span></div><button class="copy-btn btn btn-sm" data-copy-value="${escapedVal}" title="Copy value" aria-label="Copy value">Copy</button></li>`;
         }).join('');
         extractedValuesHtml = `
             <div class="result-extracted-values">
@@ -510,4 +521,18 @@ export function renderResultItemContent(listItem, resultData) {
             resultBody.appendChild(copyBtn);
         }
     }
+
+    const valueCopyBtns = listItem.querySelectorAll('.result-extracted-values .copy-btn');
+    valueCopyBtns.forEach(btn => {
+        const val = btn.getAttribute('data-copy-value') || '';
+        btn.addEventListener('click', () => {
+            try {
+                navigator.clipboard.writeText(val);
+                btn.textContent = 'Copied!';
+                setTimeout(() => { btn.textContent = 'Copy'; }, 1000);
+            } catch (err) {
+                logger.error('Failed to copy extracted value:', err);
+            }
+        });
+    });
 }

--- a/styles.css
+++ b/styles.css
@@ -988,6 +988,10 @@ button:disabled {
 .result-extracted-values li:last-child {
     margin-bottom: 0;
 }
+.result-extracted-values li .copy-btn {
+    margin-top: 4px;
+    float: right;
+}
 .result-extracted-values code {
     background-color: #dbeafe;
     padding: 1px 4px;


### PR DESCRIPTION
## Summary
- place extracted value copy buttons inside the blue container
- show temporary "Copied!" feedback when clicking
- update unit and e2e tests for new behaviour
- position copy buttons beneath variable text instead of inline

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_68528fa7ed788320a7ba8f4b7789dba7