### PR TITLE
Update layout handling

### DIFF
--- a/eventHandlers.js
+++ b/eventHandlers.js
@@ -562,8 +562,9 @@ export function handleVisualizerNodeLayoutUpdate(stepId, x, y, options = {}) {
 
         // Create a new layout object by merging current and new properties
         const newLayout = {
-            ...currentLayout, // Keep any existing unrelated properties
-            ...(collapseChanged && { collapsed: options.collapsed }) // Conditionally update collapsed
+            ...currentLayout,
+            ...(positionChanged && { x, y }),
+            ...(collapseChanged && { collapsed: options.collapsed })
         };
 
         // Update the model


### PR DESCRIPTION
## Summary
- preserve node position in layout when nodes move
- test drag behavior stores updated layout coordinates

## Testing
- `npm test`
- `npm run e2e` *(fails: domain redirector.gvt1.com blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6852b101230883208306f6ca4359e60d