### PR TITLE
Add JSON variable loop example

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,18 @@ The **Save**, **Cancel**, and **Close** buttons evaluate both flags. Save and Ca
 *   **Loop (For Each):**
     *   **Source (Array Variable):** Enter the variable name (e.g., `{{userList}}`) that holds the array you want to iterate over. This variable must exist in the context and contain an array.
     *   **Item Variable Name:** Enter the name that will hold the current item during each iteration (e.g., `item`, `user`). You can access the item's properties within the loop body using `{{item.id}}`, `{{user.name}}`, etc.
-    *   **Loop Body:** Add steps within the loop body using the `+ Add Step` button within the step's content area in the List view. These steps will execute once for each item in the source array.
+*   **Loop Body:** Add steps within the loop body using the `+ Add Step` button within the step's content area in the List view. These steps will execute once for each item in the source array.
+    *   **Example:** Define a JSON variable `userList` in the Flow Info overlay:
+
+        ```json
+        [
+            { "id": 1, "name": "Alice", "active": true },
+            { "id": 2, "name": "Bob",   "active": false }
+        ]
+        ```
+
+        Add a Loop step with **Source** `{{userList}}` and **Item Variable Name** `user`.
+        Inside the loop body you can reference `{{user.name}}` or add a Condition step checking `{{user.active}}`.
 
 ### Variables
 

--- a/help.html
+++ b/help.html
@@ -109,6 +109,12 @@
                         <li><strong>Condition (If/Else):</strong> Executes different branches (Then/Else) based on evaluating a variable against a value using an operator. Add steps to branches via the '+ Add Step' buttons inside the condition step in the List view.</li>
                         <li><strong>Loop (For Each):</strong> Repeats a sequence of steps (the Loop Body) for each item in a source array variable. Defines an 'Item Variable' (e.g., <code>item</code>) accessible within the loop body. Add steps to the body via the '+ Add Step' button inside the loop step in the List view.</li>
                     </ul>
+                    <p><em>Example:</em> Define a JSON variable <code>userList</code> in the Flow Info overlay:</p>
+                    <pre><code>[
+    { "name": "Alice", "active": true },
+    { "name": "Bob",   "active": false }
+]</code></pre>
+                    <p>Create a Loop step with source <code>{{userList}}</code> and item variable <code>user</code>. Within the loop body reference <code>{{user.name}}</code> or add a Condition step checking <code>user.active</code>.</p>
                 </div>
                  <div class="subsection">
                     <h3>Variables</h3>


### PR DESCRIPTION
## Summary
- document JSON array variable in README and help
- show loop and condition usage for item properties

## Testing
- `npm test`
- `npm run e2e` *(fails: Run flow & verify a few key results)*

------
https://chatgpt.com/codex/tasks/task_b_6852bfb989648320a0a3f7c9dede2a98