### PR TITLE
Add build helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,10 @@ npm run e2e  # runs with E2E=true
 ```
 
 These npm scripts automatically set the required environment variables.
+## Building Packages
+
+Run `build_all.sh` to install dependencies, test, and create distributables for macOS and Windows. Set `ZSCALER_CA` to your root CA if required.
+
 
 
 <div align="center" style="margin-top: 40px; padding-top: 20px; border-top: 1px solid #eee;">

--- a/build_all.sh
+++ b/build_all.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+# Optional: path to Zscaler root CA certificate
+# Pass the certificate path as the ZSCALER_CA env variable
+if [ -n "$ZSCALER_CA" ]; then
+    export NODE_EXTRA_CA_CERTS="$ZSCALER_CA"
+fi
+
+# Ensure dependencies are installed
+npm ci
+
+# Run tests before building
+npm test
+npm run e2e
+
+# Build macOS (arm64)
+echo "Building macOS package..."
+NODE_OPTIONS= npx electron-forge make --platform=darwin --arch=arm64
+
+# Build Windows (x64)
+echo "Building Windows package..."
+NODE_OPTIONS= npx electron-forge make --platform=win32 --arch=x64
+


### PR DESCRIPTION
## Summary
- add script to build FlowRunner for macOS and Windows
- document build steps in README

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_6852c452387083208e8aa73f8e28a1c1