### PR TITLE
Update default step delay to 1000ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ FlowRunner configuration happens primarily through the user interface:
 *   **Runner Settings:**
     *   **Location:** Runner Panel (right sidebar).
     *   **Settings:** Execution Delay (ms).
-    *   **Persistence:** Delay value is not saved per-flow; it resets to the default (500ms) when the application starts.
+    *   **Persistence:** Delay value is not saved per-flow; it resets to the default (1000ms) when the application starts.
 *   **UI State:**
     *   **Location:** Internal (`localStorage`).
     *   **Settings:** Collapsed state of the Sidebar and Runner Panel.

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 // --- Constants ---
 export const RECENT_FILES_KEY = 'flowrunnerRecentFiles';
 export const MAX_RECENT_FILES = 10;
-export const DEFAULT_REQUEST_DELAY = 500; // Keep this
+export const DEFAULT_REQUEST_DELAY = 1000; // Keep this in ms
 
 // --- Logging Level Config ---
 export const LOG_LEVEL = 'info'; // Possible values: 'debug', 'info', 'warn', 'error'

--- a/flowRunner.js
+++ b/flowRunner.js
@@ -14,7 +14,7 @@ const escapeRegExp = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 export class FlowRunner {
     constructor(options = {}) {
-        this.delay = options.delay ?? 500; // Delay between steps in ms
+        this.delay = options.delay ?? 1000; // Delay between steps in ms
         this.onStepStart = options.onStepStart || (() => {}); // (step, executionPath) => resultIndex
         this.onStepComplete = options.onStepComplete || (() => {}); // (resultIndex, step, result, context, executionPath) => {}
         this.onFlowComplete = options.onFlowComplete || (() => {}); // (finalContext, results) => {}

--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                     </div>
                     <div class="control-group delay-group">
                         <label for="request-delay">Delay (ms):</label>
-                        <input type="number" id="request-delay" value="500" min="0" step="100"
+                        <input type="number" id="request-delay" value="1000" min="0" step="100"
                             title="Delay between steps during 'Run' mode, and between full runs in 'Continuous Run' mode">
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- bump the default runner delay to 1000ms
- reflect new delay in UI and docs

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_6869668ac56c8320b76bacf55a1b0b5c