### PR TITLE
Fix variable insert button

### DIFF
--- a/dialogs.js
+++ b/dialogs.js
@@ -228,12 +228,31 @@ export function hideVarDropdown() {
 
 // --- [Modified Code] in app.js ---
 export function insertVariableIntoInput(varName) {
-    let targetInput = currentVarDropdown.targetInput;
-    if (!targetInput && currentVarDropdown.targetId) {
-        // Attempt to re-query the element if it was re-rendered
-        targetInput = document.getElementById(currentVarDropdown.targetId);
-        currentVarDropdown.targetInput = targetInput;
+    let targetInput = null;
+
+    // --- Recompute target each time in case of re-renders ---
+    const btn = currentVarDropdown.button;
+    const targetId = btn?.dataset.targetInput || currentVarDropdown.targetId;
+
+    if (targetId) {
+        // Try scoped query first, then global
+        targetInput = btn?.closest('.step-editor, .flow-info-overlay, .key-value-editor')?.querySelector(`#${targetId}`)
+            || document.getElementById(targetId);
     }
+
+    if (!targetInput && btn) {
+        const container = btn.closest('.input-with-vars, .header-row, .global-header-row, .flow-var-row, .key-value-row');
+        if (container) {
+            targetInput = container.querySelector('input[type="text"], input:not([type]), textarea');
+        } else {
+            targetInput = btn.previousElementSibling;
+            if (!targetInput || (targetInput.tagName !== 'INPUT' && targetInput.tagName !== 'TEXTAREA')) {
+                targetInput = btn.parentElement?.querySelector('input[type="text"], input:not([type]), textarea');
+            }
+        }
+    }
+
+    currentVarDropdown.targetInput = targetInput;
     // --- CRITICAL: Add checks ---
     if (!targetInput) {
         console.error("Cannot insert variable: Target input is null or undefined.");


### PR DESCRIPTION
## Summary
- better recover target input when inserting variables
- ensure variable dropdown can find input element even if step editor rerenders

## Testing
- `npm test`
- `npm run e2e`


------
https://chatgpt.com/codex/tasks/task_b_686a1f823da483208be02236ef1f6d9d