### PR TITLE
Fix loop editor dirty state

### DIFF
--- a/flowStepComponents.js
+++ b/flowStepComponents.js
@@ -730,10 +730,8 @@ function createLoopEditor(container, options) {
     const varInput = container.querySelector(`#loop-variable-${localStep.id}`);
     const varError = container.querySelector('.loop-var-validation-error');
 
-    // --- MODIFICATION START: Add immediate dirty listeners ---
-    varInput.addEventListener('input', () => {
-        const name = varInput.value.trim();
-        localStep.loopVariable = name;
+    // --- MODIFICATION START: Validation helper & listeners ---
+    function validateVarInput(name) {
         if (!name) {
             varError.textContent = 'Item variable name is required.';
             varError.style.display = 'block';
@@ -746,10 +744,16 @@ function createLoopEditor(container, options) {
             varError.style.display = 'none';
             varInput.style.borderColor = '';
         }
+    }
+
+    varInput.addEventListener('input', () => {
+        const name = varInput.value.trim();
+        localStep.loopVariable = name;
+        validateVarInput(name);
         setDirtyState(true); /* Immediate dirty */
     });
-    // Initial validation (doesn't mark dirty)
-    setTimeout(() => varInput.dispatchEvent(new Event('input')), 0);
+    // Initial validation without triggering dirty state
+    validateVarInput(varInput.value.trim());
 
     sourceInput.addEventListener('input', () => { localStep.source = sourceInput.value; setDirtyState(true); /* Immediate dirty */ });
     // --- MODIFICATION END ---


### PR DESCRIPTION
## Summary
- avoid marking loop editor dirty during initial validation

## Testing
- `npm test`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_b_686a9d6e88d08320a2e6dc60c00b5339