### PR TITLE
Update version references to 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 
 ## Release Notes / Changelog
 
+### v1.1.2 (July 2025)
+- **Priority One Fixes:** Resolved variable insertion issues in loops, improved full response body extraction, and fixed unsaved changes warning when deleting steps.
+- **Execution Delay:** Default delay between steps is now 1000ms.
+
 ### v1.1.1 (June 2025)
 - **Visual Editor Enhancements:**
   - Added minimap for better navigation of large flows.
@@ -108,17 +112,17 @@ This tool is particularly useful for:
 ## Prerequisites
 
 *   Windows (x64) or macOS (Apple Silicon / arm64).
-*   The appropriate FlowRunner installer package downloaded from the [v1.1.1 Release Page](https://github.com/Radware/FlowRunner/releases/tag/v1.1.1) (or latest release).
+*   The appropriate FlowRunner installer package downloaded from the [v1.1.2 Release Page](https://github.com/Radware/FlowRunner/releases/tag/v1.1.2) (or latest release).
 *   Network access is required *only* when executing flows that contain 'API Request' steps which need to reach external endpoints. Flow authoring, saving, loading, and visualization can be done offline.
 
 ## Installation
 
 1.  **Download the Correct Installer:**
     *   Go to the [FlowRunner Releases Page](https://github.com/Radware/FlowRunner/releases) on GitHub.
-    *   Find the latest release (e.g., v1.1.1).
+    *   Find the latest release (e.g., v1.1.2).
     *   Under **Assets**:
-        *   For **Windows (x64)**, download `FlowRunnerSetup-x64-win-1.1.1.zip`. Unzip the file to find the `Setup.exe`.
-        *   For **macOS (Apple Silicon / arm64)**, download `FlowRunnerSetup-arm64-mac-1.1.1.dmg`.
+        *   For **Windows (x64)**, download `FlowRunnerSetup-x64-win-1.1.2.zip`. Unzip the file to find the `Setup.exe`.
+        *   For **macOS (Apple Silicon / arm64)**, download `FlowRunnerSetup-arm64-mac-1.1.2.dmg`.
 2.  **Install on Windows:**
     *   Double-click the extracted `Setup.exe` file.
     *   The installation will proceed silently in the background (using Squirrel.Windows). It typically installs to your `AppData\Local\FlowRunner` folder.

--- a/development_tasks.md
+++ b/development_tasks.md
@@ -48,7 +48,7 @@ This document breaks down the features and improvements planned in the roadmap i
 
 ---
 
-## v1.1.1 Tasks: Quality, Testing & Refinement
+## v1.1.2 Tasks: Quality, Testing & Refinement
 
 *   **Recent Files Management:**
     *   [x] Design UI interaction for removing a recent file (e.g., 'X' button, right-click context menu).

--- a/e2e/mockUpdate.js
+++ b/e2e/mockUpdate.js
@@ -4,8 +4,8 @@ export async function setupMockUpdateRoute(page) {
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify({
-                tag_name: 'v1.1.1',
-                html_url: 'https://example.com/release/v1.1.1'
+                tag_name: 'v1.1.2',
+                html_url: 'https://example.com/release/v1.1.2'
             })
         });
     });

--- a/release.md
+++ b/release.md
@@ -1,8 +1,8 @@
-# FlowRunner v1.1.1 - Enhanced Visual Editor with Minimap & Improved Variable Management
+# FlowRunner v1.1.2 - Enhanced Visual Editor with Minimap & Improved Variable Management
 
-FlowRunner v1.1.1 delivers significant enhancements to the visual editing experience, introduces powerful navigation tools for large flows, and provides better variable handling capabilities. This release focuses on making complex flow creation and debugging more intuitive and efficient.
+FlowRunner v1.1.2 delivers significant enhancements to the visual editing experience, introduces powerful navigation tools for large flows, and provides better variable handling capabilities. This release focuses on making complex flow creation and debugging more intuitive and efficient. It also resolves all Priority&nbsp;1 issues from the `todo.md` list and sets the default delay between steps to **1000&nbsp;ms**.
 
-## ✨ Key New Features in v1.1.1
+## ✨ Key New Features in v1.1.2
 
 ### 🗺️ **Minimap & Enhanced Navigation**
 *   **Interactive Minimap:** Navigate large flows effortlessly with the new minimap in Node-Graph view
@@ -72,21 +72,21 @@ FlowRunner v1.1.1 delivers significant enhancements to the visual editing experi
 
 Download the appropriate installer for your operating system:
 
-*   **Windows (x64):** `FlowRunnerSetup-x64-win-1.1.1.zip` (Contains `Setup.exe`)
-*   **macOS (Apple Silicon / arm64):** `FlowRunnerSetup-arm64-mac-1.1.1.dmg`
+*   **Windows (x64):** `FlowRunnerSetup-x64-win-1.1.2.zip` (Contains `Setup.exe`)
+*   **macOS (Apple Silicon / arm64):** `FlowRunnerSetup-arm64-mac-1.1.2.dmg`
 
 ## ⚠️ Installation Notes & Troubleshooting
 
 These builds remain unsigned. Please follow the same installation procedures as previous versions:
 
 ### **Windows Installation:**
-1. Download and extract `FlowRunnerSetup-x64-win-1.1.1.zip`
+1. Download and extract `FlowRunnerSetup-x64-win-1.1.2.zip`
 2. Run `Setup.exe` 
 3. If Windows SmartScreen appears, click "More info" → "Run anyway"
 4. The installer runs silently and launches the app automatically
 
 ### **macOS Installation:**
-1. Download `FlowRunnerSetup-arm64-mac-1.1.1.dmg`
+1. Download `FlowRunnerSetup-arm64-mac-1.1.2.dmg`
 2. Open the DMG and drag FlowRunner to Applications
 3. If you see "FlowRunner is damaged" error, run in Terminal:
    ```bash
@@ -103,7 +103,7 @@ These builds remain unsigned. Please follow the same installation procedures as 
 
 ## 🔄 Upgrade Notes
 
-Flows created in v1.1.0 are fully compatible with v1.1.1. The new variable typing system is optional - existing flows will continue to work exactly as before, with all variables treated as strings unless you explicitly change their types.
+Flows created in v1.1.0 are fully compatible with v1.1.2. The new variable typing system is optional - existing flows will continue to work exactly as before, with all variables treated as strings unless you explicitly change their types.
 
 ## 🚀 What's Next?
 


### PR DESCRIPTION
## Summary
- bump remaining mentions of FlowRunner 1.1.1 to 1.1.2
- document Priority 1 fixes and new default delay in README and release notes
- update mock update test version
- update development tasks heading

## Testing
- `npm test`
- `npm run e2e` *(fails: E2E: Comprehensive Flow Execution > Run flow & verify a few key results)*

------
https://chatgpt.com/codex/tasks/task_b_686ac2c95cf88320a90686e6a6961eb9