### PR TITLE
Update docs and package configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Release Notes / Changelog
 
 ### v1.1.2 (July 2025)
-- **Priority One Fixes:** Resolved variable insertion issues in loops, improved full response body extraction, and fixed unsaved changes warning when deleting steps.
+- **Bug Fixes:** Resolved variable insertion issues in loops, improved full response body extraction, and fixed unsaved changes warning when deleting steps.
 - **Execution Delay:** Default delay between steps is now 1000ms.
 
 ### v1.1.1 (June 2025)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "flowrunner",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "API Flow Creation and Visualization Tool",
   "main": "main.js",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "start": "electron .",
     "postinstall": "electron-builder install-app-deps",

--- a/release.md
+++ b/release.md
@@ -1,6 +1,6 @@
 # FlowRunner v1.1.2 - Enhanced Visual Editor with Minimap & Improved Variable Management
 
-FlowRunner v1.1.2 delivers significant enhancements to the visual editing experience, introduces powerful navigation tools for large flows, and provides better variable handling capabilities. This release focuses on making complex flow creation and debugging more intuitive and efficient. It also resolves all Priority&nbsp;1 issues from the `todo.md` list and sets the default delay between steps to **1000&nbsp;ms**.
+FlowRunner v1.1.2 delivers significant enhancements to the visual editing experience, introduces powerful navigation tools for large flows, and provides better variable handling capabilities. This release focuses on making complex flow creation and debugging more intuitive and efficient. It sets the default delay between steps to **1000 ms**.
 
 ## ✨ Key New Features in v1.1.2
 

--- a/todo.md
+++ b/todo.md
@@ -1,12 +1,12 @@
 # priority 1.
 
- - when trying to add a variable in loop in source field using the add variable button i get this error - Cannot insert variable: Target input is null or undefined.
+- [x] when trying to add a variable in loop in source field using the add variable button i get this error - Cannot insert variable: Target input is null or undefined.
 insertVariableIntoInput @ dialogs.js:234
 (anonymous) @ dialogs.js:86 
 
- - require the option to properly extract body of a  response, for example if the response is a json array i need to extract all of it to one variable, currently if i write body it seems to paste all of responses of all the requests from the flow or at least the same response many times because even though the response was rather small the extracted response was huge.
+- [x] require the option to properly extract body of a  response, for example if the response is a json array i need to extract all of it to one variable, currently if i write body it seems to paste all of responses of all the requests from the flow or at least the same response many times because even though the response was rather small the extracted response was huge.
 
- - i have noticed that if i delete a step and the step editor is currently empty i cannot save because i get an error that i have unsaved changes in the step, it only works if i click on another step and dismiss the warning and then save.
+- [x] i have noticed that if i delete a step and the step editor is currently empty i cannot save because i get an error that i have unsaved changes in the step, it only works if i click on another step and dismiss the warning and then save.
 
 # priority 2
 


### PR DESCRIPTION
## Summary
- bump `package-lock.json` to v1.1.2
- remove todo references from release notes
- revise changelog entry for v1.1.2
- mark resolved items in `todo.md`
- enforce Node 18+ in `package.json`

## Testing
- `npm test`
- `npm run e2e` *(fails: locator not visible)*

------
https://chatgpt.com/codex/tasks/task_b_686b76acaa408320accae8ca23e0f89c